### PR TITLE
Initial support of modifiers

### DIFF
--- a/contracts/access/access-control/impls.rs
+++ b/contracts/access/access-control/impls.rs
@@ -92,7 +92,7 @@ pub trait AccessControl: AccessControlStorage {
 
     // Internal functions
 
-    fn _init(&mut self) {
+    fn _init_with_caller(&mut self) {
         let caller = Self::env().caller();
         self._init_with_admin(caller);
     }
@@ -127,7 +127,6 @@ pub trait AccessControl: AccessControlStorage {
         }
     }
 
-    #[inline]
     fn _check_role(&self, role: &RoleType, address: &AccountId) {
         assert!(self._has_role(role, address), "{}", AccessControlError::MissingRole.as_ref())
     }

--- a/contracts/access/access-control/tests.rs
+++ b/contracts/access/access-control/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[brush::contract]
 mod tests {
-    use crate::traits::{RoleType};
+    use crate::traits::{RoleType, IAccessControl};
     use crate::impls::{AccessControlStorage, AccessControl, RoleData, DEFAULT_ADMIN_ROLE, StorageHashMap};
     use ink_env::test::DefaultAccounts;
     use ::ink_env::{DefaultEnvironment};
@@ -17,7 +17,7 @@ mod tests {
     // ::ink_lang_ir::Selector::new("PAUSER".as_ref()).as_bytes()
     const PAUSER: RoleType = 0x4ce9afe6;
 
-    #[derive(Default, AccessControlStorage)]
+    #[derive(Default, AccessControlStorage, IAccessControl)]
     #[ink(storage)]
     pub struct AccessControlStruct {}
 
@@ -25,15 +25,16 @@ mod tests {
     impl AccessControl for AccessControlStruct {}
 
     impl AccessControlStruct {
+        pub fn new(admin: AccountId) -> impl AccessControl {
+            Self::constructor(admin)
+        }
+
         #[ink(constructor)]
-        pub fn new(admin: AccountId) -> Self {
+        pub fn constructor(admin: AccountId) -> Self {
             let mut instance = Self::default();
             instance._init_with_admin(admin);
             instance
         }
-
-        #[ink(message)]
-        pub fn temp(&self) {}
     }
 
     fn setup() -> DefaultAccounts<DefaultEnvironment> {

--- a/contracts/access/ownable/impls.rs
+++ b/contracts/access/ownable/impls.rs
@@ -26,14 +26,11 @@ pub trait Ownable: OwnableStorage {
     }
 
     fn renounce_ownership(&mut self) {
-        self.only_owner();
-
         // TODO: Emit event
         *self._owner_mut() = ZERO_ADDRESS.into();
     }
 
     fn transfer_ownership(&mut self, new_owner: AccountId) {
-        self.only_owner();
         assert_ne!(new_owner, ZERO_ADDRESS.into(), "{}", OwnableError::NewOwnerIsZero.as_ref());
         // TODO: Emit event
         *self._owner_mut() = new_owner;

--- a/contracts/access/ownable/traits.rs
+++ b/contracts/access/ownable/traits.rs
@@ -1,4 +1,5 @@
 use brush::traits::{AccountId};
+use brush::modifiers;
 
 #[derive(strum_macros::AsRefStr)]
 pub enum OwnableError {
@@ -12,8 +13,10 @@ pub trait IOwnable {
     fn owner(&self) -> AccountId;
 
     #[ink(message)]
+    #[modifiers(only_owner)]
     fn renounce_ownership(&mut self);
 
     #[ink(message)]
+    #[modifiers(only_owner)]
     fn transfer_ownership(&mut self, new_owner: AccountId);
 }

--- a/contracts/brush/lib.rs
+++ b/contracts/brush/lib.rs
@@ -5,4 +5,5 @@ pub use proc_macros::{
     contract,
     trait_definition,
     internal_trait_definition,
+    modifiers,
 };

--- a/contracts/brush/proc_macros/contract.rs
+++ b/contracts/brush/proc_macros/contract.rs
@@ -1,0 +1,120 @@
+use crate::internal;
+use quote::{
+    quote,
+};
+use syn::{
+    Item,
+};
+use proc_macro::TokenStream;
+use proc_macro2::{
+    TokenStream as TokenStream2,
+    TokenTree,
+};
+use fs2::FileExt;
+
+pub(crate) fn generate(_attrs: TokenStream, ink_module: TokenStream) -> TokenStream {
+    let input: TokenStream2 = ink_module.into();
+    let attrs: TokenStream2 = _attrs.into();
+    let mut module = syn::parse2::<syn::ItemMod>(input.clone()).expect("Can't parse contract module");
+    let (braces, items) = match module.content {
+        Some((brace, items)) => (brace, items),
+        None => {
+            panic!(
+                "{}", "out-of-line ink! modules are not supported, use `#[ink::contract] mod name {{ ... }}`",
+            )
+        }
+    };
+    let locked_file = internal::get_locked_file();
+    let metadata = internal::load_metadata(&locked_file);
+    locked_file.unlock().expect("Can't remove exclusive lock in extract_fields_and_methods");
+
+    let mut new_items: Vec<syn::Item> = vec![];
+    let mut items: Vec<syn::Item> = items
+        .into_iter()
+        .filter_map(|mut item| {
+            if let Item::Struct(item_struct) = &mut item {
+                let struct_ident = item_struct.ident.clone();
+                let attrs: Vec<syn::Attribute> = item_struct.attrs.clone().iter_mut().map(|attr| {
+                    if attr.path.is_ident("derive") {
+                        let (fields, impls) =
+                            consume_derive(&struct_ident, attr, &metadata);
+
+                        let mut generated_items: Vec<_> = impls
+                            .into_iter()
+                            .map(|impl_stream| {
+                                syn::parse::<syn::ItemImpl>(impl_stream)
+                                    .expect("Can't parse generated implementation")
+                            })
+                            .map(|item_impl| syn::Item::from(item_impl))
+                            .collect();
+
+                        new_items.append(&mut generated_items);
+
+                        if let syn::Fields::Named(name_fields) = &mut item_struct.fields {
+                            fields.into_iter().for_each(|field| name_fields.named.push(field));
+                        } else {
+                            panic!("Contract support only named fields")
+                        }
+                    }
+                    attr.clone()
+                }).collect();
+                item_struct.attrs = attrs;
+            }
+            Some(item)
+        }).collect();
+
+    items.append(&mut new_items);
+    module.content = Some((braces, items));
+
+    let result = quote! {
+        #attrs
+        #[ink_lang::contract]
+        #module
+    };
+    result.into()
+}
+
+fn consume_derive(struct_ident: &syn::Ident,
+                  attr: &mut syn::Attribute, metadata: &internal::Metadata) -> (Vec<syn::Field>, Vec<TokenStream>) {
+    let mut fields: Vec<syn::Field> = vec![];
+    let mut impls: Vec<TokenStream> = vec![];
+    let tokens: TokenStream2 = attr.tokens.clone().into_iter().map(|token|
+        if let TokenTree::Group(group) = token {
+            let mut last_punct = false;
+            let filtered_stream: TokenStream2 = group.stream().into_iter().filter_map(|token|
+                if let TokenTree::Punct(_) = token {
+                    if last_punct {
+                        None
+                    } else {
+                        last_punct = true;
+                        Some(token)
+                    }
+                } else if let TokenTree::Ident(ident) = &token {
+                    let key = ident.to_string();
+                    if metadata.internal_traits.contains_key(&key) {
+                        let (mut _fields, _impl) = internal::impl_internal_trait(struct_ident, ident, metadata);
+                        fields.append(&mut _fields);
+                        impls.push(_impl);
+                        None
+                    } else if metadata.external_traits.contains_key(&key) {
+                        let _impl = internal::impl_external_trait(struct_ident, ident, metadata);
+                        impls.push(_impl);
+                        None
+                    } else {
+                        last_punct = false;
+                        Some(token)
+                    }
+                } else {
+                    last_punct = false;
+                    Some(token)
+                }
+            ).collect();
+
+            proc_macro2::Group::new(group.delimiter(), filtered_stream).into()
+        } else {
+            token
+        }
+    ).collect();
+    attr.tokens = tokens;
+    (fields, impls)
+}

--- a/contracts/brush/proc_macros/lib.rs
+++ b/contracts/brush/proc_macros/lib.rs
@@ -95,7 +95,7 @@ fn add_modifiers_to_block(block: &mut syn::Block, modifiers: Vec<syn::Ident>) {
         .into_iter()
         .for_each(|ident| {
             let code = quote! {
-                self.#ident();
+                #[cfg(not(feature = "ink-as-dependency"))] self.#ident();
             };
             block.stmts.insert(0, syn::parse2::<syn::Stmt>(code)
                 .expect("Can't parse statement of modifier"));

--- a/contracts/token/psp1155/tests.rs
+++ b/contracts/token/psp1155/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[brush::contract]
 mod tests {
-    use crate::traits::{Id};
+    use crate::traits::{Id, IPSP1155};
     use crate::impls::{PSP1155Storage, PSP1155};
     use ink_prelude::{vec::Vec, vec};
     use ink_storage::{
@@ -46,7 +46,7 @@ mod tests {
         approved: bool,
     }
 
-    #[derive(Default, PSP1155Storage)]
+    #[derive(Default, PSP1155Storage, IPSP1155)]
     #[ink(storage)]
     pub struct PSP1155Struct {}
 
@@ -84,13 +84,14 @@ mod tests {
     }
 
     impl PSP1155Struct {
-        #[ink(constructor)]
-        pub fn new() -> Self {
-            Self::default()
+        pub fn new() -> impl PSP1155 {
+            Self::constructor()
         }
 
-        #[ink(message)]
-        pub fn temp(&self) {}
+        #[ink(constructor)]
+        pub fn constructor() -> Self {
+            Self::default()
+        }
     }
 
     type Event = <PSP1155Struct as ::ink_lang::BaseEvent>::Type;

--- a/contracts/token/psp20/tests.rs
+++ b/contracts/token/psp20/tests.rs
@@ -3,6 +3,7 @@
 mod tests {
     /// Imports all the definitions from the outer scope so we can use them here.
     use crate::impls::{PSP20, PSP20Storage, StorageHashMap, Lazy};
+    use crate::traits::{IPSP20};
     use ink_prelude::{string::{String}};
     use ink_lang as ink;
     use brush::{
@@ -42,7 +43,7 @@ mod tests {
 
     /// A simple PSP-20 contract.
     #[ink(storage)]
-    #[derive(Default, PSP20Storage)]
+    #[derive(Default, PSP20Storage, IPSP20)]
     pub struct PSP20Struct {}
     type Event = <PSP20Struct as ::ink_lang::BaseEvent>::Type;
 
@@ -66,15 +67,16 @@ mod tests {
     }
 
     impl PSP20Struct {
+        pub fn new(_total_supply: Balance) -> impl PSP20 {
+            Self::constructor(_total_supply)
+        }
+
         #[ink(constructor)]
-        pub fn new(_total_supply: Balance) -> Self {
+        pub fn constructor(_total_supply: Balance) -> Self {
             let mut instance = Self::default();
             instance.mint(instance.env().caller(), _total_supply);
             instance
         }
-
-        #[ink(message)]
-        pub fn temp(&self){}
     }
 
     fn assert_transfer_event(

--- a/contracts/token/psp721/tests.rs
+++ b/contracts/token/psp721/tests.rs
@@ -8,7 +8,7 @@ mod tests {
         traits::{InkStorage},
     };
     use ink::{Env, EmitEvent};
-    use crate::traits::{ Id };
+    use crate::traits::{ Id, IPSP721, IPSP721Metadata, IPSP721Mint };
     use crate::impls::{ PSP721Storage, PSP721, PSP721Mint, PSP721MetadataStorage, PSP721Metadata, StorageHashMap };
 
     const ZERO_ADDRESS: [u8; 32] = [0; 32];
@@ -46,7 +46,7 @@ mod tests {
         approved: bool,
     }
 
-    #[derive(Default, PSP721Storage, PSP721MetadataStorage)]
+    #[derive(Default, PSP721Storage, PSP721MetadataStorage, IPSP721, IPSP721Metadata, IPSP721Mint)]
     #[ink(storage)]
     pub struct PSP721Struct {}
 
@@ -80,15 +80,16 @@ mod tests {
     impl PSP721Metadata for PSP721Struct {}
 
     impl PSP721Struct {
+        pub fn new(name: Option<String>, symbol: Option<String>) -> impl PSP721 + PSP721Metadata + PSP721Mint {
+            Self::constructor(name, symbol)
+        }
+
         #[ink(constructor)]
-        pub fn new(name: Option<String>, symbol: Option<String>) -> Self {
+        pub fn constructor(name: Option<String>, symbol: Option<String>) -> Self {
             let mut instance = Self::default();
             instance._init_with_metadata(name, symbol);
             instance
         }
-
-        #[ink(message)]
-        pub fn temp(&self) {}
     }
 
     #[ink::test]

--- a/examples/access-control/lib.rs
+++ b/examples/access-control/lib.rs
@@ -12,6 +12,7 @@ pub mod my_access_control {
     };
     use brush::{
         traits::{ InkStorage },
+        modifiers,
     };
     use ink_prelude::{ vec::Vec };
 
@@ -47,14 +48,14 @@ pub mod my_access_control {
     impl PSP721Mint for PSP721Struct {}
     impl IPSP721Mint for PSP721Struct {
         #[ink(message)]
+        #[modifiers(only_minter)]
         fn mint(&mut self, id: Id) {
-            self.only_minter();
             PSP721Mint::mint(self, id);
         }
 
         #[ink(message)]
+        #[modifiers(only_minter)]
         fn burn(&mut self, id: Id) {
-            self.only_minter();
             PSP721Mint::burn(self, id);
         }
     }


### PR DESCRIPTION
Added initial support of modifiers. Now anyone can put macro for method and if it has a code of block, it will put `self.name_of_modifier();` call there.

Force building of external trait inheritance in tests.