### PR TITLE
Redesigned modifiers

### DIFF
--- a/contracts/access/ownable/traits.rs
+++ b/contracts/access/ownable/traits.rs
@@ -18,6 +18,16 @@ pub enum OwnableError {
     NewOwnerIsZero,
 }
 
+#[modifier_definition]
+pub fn only_owner<T, F, ReturnType>(instance: &mut T, mut body: F) -> ReturnType
+    where
+        T: OwnableStorage,
+        F: FnMut(&mut T) -> ReturnType,
+{
+    assert_eq!(instance._owner(), &T::env().caller(), "{}", OwnableError::CallerIsNotOwner.as_ref());
+    body(instance)
+}
+
 #[brush::trait_definition]
 pub trait IOwnable: OwnableStorage {
     #[ink(message)]
@@ -43,12 +53,6 @@ pub trait IOwnable: OwnableStorage {
     }
     
     // Helper functions
-
-    #[modifier_definition]
-    fn only_owner(&self) {
-        assert_eq!(self._owner(), &Self::env().caller(), "{}", OwnableError::CallerIsNotOwner.as_ref());
-        #[body]()
-    }
 
     /// User must override this method in their contract.
     fn _emit_ownership_transferred_event(&self, _previous_owner: Option<AccountId>, _new_owner: Option<AccountId>) {}

--- a/contracts/brush/proc_macros/lib.rs
+++ b/contracts/brush/proc_macros/lib.rs
@@ -262,11 +262,11 @@ pub fn storage_trait(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
 /// This macro only checks that some free-standing function satisfies a set of rules.
 ///
 /// Rules:
-/// - First argument is not `self` argument.
-/// - First argument must be reference to some type `instance: &T`. In most cases it is instance of contract.
+/// - First argument should not be `self`.
+/// - First argument must be a reference to a type `instance: &T`. In most cases it's the instance of contract.
 /// - Second argument is function's body(this function contains the main code of method attached to the modifier).
 /// The type must be `Fn(&T)` or `FnMut(&T)`.
-/// - Every next argument is not references to object.
+/// - Every next argument should not be references to object.
 /// Because modifier allows only to pass arguments by value(Modifier will pass the clone of argument).
 /// - The return type of body function(second argument) must be the same as the return type of modifier.
 ///
@@ -280,7 +280,7 @@ pub fn storage_trait(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
 ///
 /// #[brush::modifier_definition]
 /// fn once<BodyFn: Fn(&mut Contract)>(instance: &mut Contract, body: BodyFn, _example_data: u8) {
-///     assert!(!instance.initialized, "Contract already is initialized");
+///     assert!(!instance.initialized, "Contract is already initialized");
 ///     body(instance);
 ///     instance.initialized = true;
 /// }
@@ -290,8 +290,8 @@ pub fn modifier_definition(_attrs: TokenStream, _input: TokenStream) -> TokenStr
     modifier_definition::generate(_attrs, _input)
 }
 
-/// Macro calls every modifier function by passing self and code of function's body.
-/// It means that modifiers must be available in the scope of marked method.
+/// Macro calls every modifier function by passing self and the code of function's body.
+/// It means that modifiers must be available in the scope of the marked method.
 ///
 /// Modifiers are designed to be used for methods in impl sections.
 /// The method can have several modifiers. They will be expanded from left to right.
@@ -399,7 +399,7 @@ pub fn modifier_definition(_attrs: TokenStream, _input: TokenStream) -> TokenStr
 ///
 ///     #[brush::modifier_definition]
 ///     fn once(instance: &mut Contract, body: impl Fn(&mut Contract)) {
-///         assert!(!instance.initialized, "Contract already is initialized");
+///         assert!(!instance.initialized, "Contract is already initialized");
 ///         body(instance);
 ///         instance.initialized = true;
 ///     }

--- a/contracts/brush/proc_macros/metadata.rs
+++ b/contracts/brush/proc_macros/metadata.rs
@@ -1,4 +1,4 @@
-use syn::{TraitItem, ItemTrait, ImplItemMethod};
+use syn::{TraitItem, ItemTrait};
 use proc_macro2::{
     TokenStream as TokenStream2,
 };
@@ -53,7 +53,6 @@ impl std::ops::DerefMut for ModifierDefinitions {
 pub(crate) struct Metadata {
     pub storage_traits: TraitDefinitions,
     pub external_traits: TraitDefinitions,
-    pub modifiers: ModifierDefinitions,
 }
 
 impl Metadata {
@@ -69,16 +68,6 @@ impl Metadata {
         locked_file.seek(SeekFrom::Start(0)).expect("Can't set cursor position");
         serde_json::to_writer(&locked_file, self).expect("Can't dump definition metadata to file");
         locked_file.unlock().expect("Can't remove exclusive lock");
-    }
-}
-
-pub(crate) struct ModifierDefinition(syn::ImplItemMethod);
-
-impl std::ops::Deref for ModifierDefinition {
-    type Target = syn::ImplItemMethod;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 
@@ -109,20 +98,6 @@ impl TraitDefinitions {
 
         TraitDefinition {
             0: trait_item,
-        }
-    }
-}
-
-impl ModifierDefinitions {
-    pub(crate) fn get(&self, ident: &String) -> ModifierDefinition {
-        let stream = unwrap!(TokenStream2::from_str(
-            unwrap!(self.0.get(ident), "Can't find definition of modifier {}", ident)
-        ), "Modifier definition({}) is not TokenStream", ident);
-        let method_item =
-            unwrap!(syn::parse2::<ImplItemMethod>(stream), "Can't parse ImplItemMethod of {}", ident);
-
-        ModifierDefinition {
-            0: method_item,
         }
     }
 }

--- a/contracts/brush/proc_macros/modifier_definition.rs
+++ b/contracts/brush/proc_macros/modifier_definition.rs
@@ -18,8 +18,8 @@ pub(crate) fn generate(_: TokenStream, _input: TokenStream) -> TokenStream {
         return (quote_spanned! {
                 fn_item.sig.inputs.span() =>
                     compile_error!(
-                        "Modifier must takes at least two arguments. \
-                        Where first is reference on instance `instance: \
+                        "Modifier must take at least two arguments, \
+                        where first is a reference to instance `instance: \
                         & Trait/Struct` and second is Fn or FnMut");
             }).into();
     }
@@ -32,7 +32,7 @@ pub(crate) fn generate(_: TokenStream, _input: TokenStream) -> TokenStream {
         } else {
             return (quote_spanned! {
                 pat.ty.as_ref().span() =>
-                    compile_error!("First argument of modifier must be reference on instance `&T` or `&mut T`");
+                    compile_error!("First argument of modifier must be a reference to instance `&T` or `&mut T`");
             }).into()
         }
     } else {
@@ -150,7 +150,7 @@ pub(crate) fn generate(_: TokenStream, _input: TokenStream) -> TokenStream {
                 return (quote_spanned! {
                     refer.span() =>
                         compile_error!("The argument is a reference. \
-                        Modifier accepts arguments only by value which supports `Clone` trait.");
+                        Modifier only accepts arguments which implement `Clone` trait and only by value.");
                 }).into();
             }
         } else {

--- a/contracts/brush/proc_macros/modifier_definition.rs
+++ b/contracts/brush/proc_macros/modifier_definition.rs
@@ -1,47 +1,170 @@
 use quote::{
+    quote,
+    quote_spanned,
     ToTokens,
 };
 use syn::{
-    ImplItemMethod,
+    ItemFn,
     parse_macro_input,
+    spanned::Spanned,
 };
 use proc_macro::{TokenStream};
-use crate::metadata;
 use crate::internal::is_attr;
 
 pub(crate) fn generate(_: TokenStream, _input: TokenStream) -> TokenStream {
-    let mut impl_item = parse_macro_input!(_input as ImplItemMethod);
+    let fn_item = parse_macro_input!(_input as ItemFn);
 
-    let locked_file = metadata::get_locked_file();
-    let mut metadata = metadata::Metadata::load(&locked_file);
-    metadata.modifiers.insert(
-        impl_item.sig.ident.to_string(), impl_item.clone().into_token_stream().to_string());
-    metadata.save_and_unlock(locked_file);
+    if fn_item.sig.inputs.len() < 2 {
+        return (quote_spanned! {
+                fn_item.sig.inputs.span() =>
+                    compile_error!(
+                        "Modifier must takes at least two arguments. \
+                        Where first is reference on instance `instance: \
+                        & Trait/Struct` and second is Fn or FnMut");
+            }).into();
+    }
 
-    let bodies: Vec<_> = impl_item.block.stmts
-        .iter_mut()
-        .filter_map(|stmt|
-            match stmt {
-                syn::Stmt::Expr(exp) => Some(exp),
-                syn::Stmt::Semi(exp, _) => Some(exp),
-                _ => None,
-            })
-        .filter_map(|expr|
-            if let syn::Expr::Tuple(tuple) = expr {
-                if is_attr(&tuple.attrs, "body") {
-                    Some(tuple)
+    let instance_ty: syn::TypeReference;
+    let first = fn_item.sig.inputs.first().unwrap();
+    if let syn::FnArg::Typed(pat) = first {
+        if let syn::Type::Reference(refer) = pat.ty.as_ref() {
+            instance_ty = refer.clone();
+        } else {
+            return (quote_spanned! {
+                pat.ty.as_ref().span() =>
+                    compile_error!("First argument of modifier must be reference on instance `&T` or `&mut T`");
+            }).into()
+        }
+    } else {
+        return (quote_spanned! {
+            first.span() =>
+                compile_error!("First argument of modifier can't be `self`");
+        }).into()
+    }
+
+    let return_ty = fn_item.sig.output.clone();
+    let mut fn_string = format!("Fn({}) {}",
+        instance_ty.to_token_stream().to_string(),
+        return_ty.to_token_stream().to_string()
+    );
+
+    let mut fn_mut_string = format!("FnMut({}) {}",
+        instance_ty.to_token_stream().to_string(),
+        return_ty.to_token_stream().to_string()
+    );
+    let err_message = format!(
+        "Second argument of modifier must be body `{}` or `{}`", fn_string.as_str(), fn_mut_string.as_str());
+
+    fn_string.retain(|c| !c.is_whitespace());
+    fn_mut_string.retain(|c| !c.is_whitespace());
+
+    let second = fn_item.sig.inputs.iter().skip(1).next().unwrap();
+    if let syn::FnArg::Typed(pat) = second {
+        let mut found = false;
+        let mut found_ty = None;
+        let mut found_span = None;
+        let mut t = pat.ty.to_token_stream().to_string();
+        t.retain(|c| !c.is_whitespace());
+        if t.contains(&fn_string) || t.contains(&fn_mut_string) {
+            found_ty = Some(t.clone());
+            found_span = Some(pat.ty.span().clone());
+            found = true;
+        }
+
+        let generic = fn_item.sig.generics.params
+            .iter()
+            .filter_map(|param|
+                if let syn::GenericParam::Type(type_param) = &param {
+                    Some(type_param)
                 } else {
                     None
+                })
+            .find(|type_param| type_param.ident.to_string() == t);
+
+        if let Some(generic) = generic {
+            if let Some(generic_bound) = &generic.bounds.first() {
+                let mut t = generic_bound.to_token_stream().to_string();
+                t.retain(|c| !c.is_whitespace());
+                if t.contains(&fn_string) || t.contains(&fn_mut_string) {
+                    found_ty = Some(t);
+                    found_span = Some(generic_bound.span().clone());
+                    found = true;
                 }
-            } else {
-                None
-            })
-        .collect();
+            }
+        }
 
-    assert!(!bodies.is_empty(), "Modifier must contains definition of `#[body]();`");
-    assert_eq!(bodies.len(), 1, "Modifier contains more than one place for body. Must be only one `#[body]();`");
+        if let Some(where_clause) = &fn_item.sig.generics.where_clause {
+            let predicate = where_clause.predicates
+                .iter()
+                .filter_map(|pred|
+                    if let syn::WherePredicate::Type(type_pred) = &pred {
+                        Some(type_pred)
+                    } else {
+                        None
+                    })
+                .find(|type_pred| type_pred.bounded_ty.to_token_stream().to_string() == t);
 
-    TokenStream::new()
+            if let Some(pred) = predicate {
+                if let Some(pred_bound) = pred.bounds.first() {
+                    let mut t = pred_bound.to_token_stream().to_string();
+                    t.retain(|c| !c.is_whitespace());
+                    if t.contains(&fn_string) || t.contains(&fn_mut_string) {
+                        found_ty = Some(t);
+                        found_span = Some(pred_bound.span().clone());
+                        found = true;
+                    }
+                }
+            }
+        }
+
+        if !found {
+            return (quote_spanned! {
+                pat.ty.span() =>
+                    compile_error!(#err_message);
+            }).into();
+        } else {
+            let mut modifier_ty_str = fn_item.sig.output.to_token_stream().to_string();
+            modifier_ty_str.retain(|c| !c.is_whitespace());
+            let found_ty = found_ty.unwrap();
+
+            let found_index = found_ty.find("->").unwrap_or(found_ty.len());
+            let found_ty_str = &found_ty[found_index..];
+
+            if found_ty_str != modifier_ty_str {
+                return (quote_spanned! {
+                    found_span.unwrap().span() =>
+                        compile_error!("Return type of body mismatched with return type of modifier");
+                }).into();
+            }
+        }
+    } else if let syn::FnArg::Receiver(rec) = first {
+        return (quote_spanned! {
+            rec.span() =>
+                compile_error!("Second argument of modifier can't be `self`");
+        }).into()
+    }
+
+    for arg in fn_item.sig.inputs.iter().skip(2) {
+        if let syn::FnArg::Typed(arg) = arg {
+            if let syn::Type::Reference(refer) = arg.ty.as_ref() {
+                return (quote_spanned! {
+                    refer.span() =>
+                        compile_error!("The argument is a reference. \
+                        Modifier accepts arguments only by value which supports `Clone` trait.");
+                }).into();
+            }
+        } else {
+            return (quote_spanned! {
+                arg.span() =>
+                    compile_error!("`self` is not allowed.");
+            }).into();
+        }
+    }
+
+    let code = quote! {
+        #fn_item
+    };
+    code.into()
 }
 
 pub(crate) fn extract_modifier_definitions_trait(trait_item: &mut syn::ItemTrait) {

--- a/contracts/brush/proc_macros/modifiers.rs
+++ b/contracts/brush/proc_macros/modifiers.rs
@@ -1,34 +1,45 @@
 use quote::{
     quote,
+    quote_spanned,
     format_ident,
     ToTokens,
 };
 use syn::{
     ImplItemMethod,
+    parse_macro_input,
+    spanned::Spanned,
 };
 use proc_macro::{TokenStream};
 use proc_macro2::{
     TokenStream as TokenStream2,
     TokenTree,
 };
-use crate::metadata;
-use crate::internal::is_attr;
+
+const INSTANCE: &'static str = "__brush_instance_modifier";
 
 pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
-    let attrs: TokenStream2 = _attrs.into();
     let input: TokenStream2 = _input.clone().into();
-    let modifiers: Vec<_> = attrs
-        .into_iter()
-        .filter_map(|token|
-            if let TokenTree::Ident(ident) = token {
-                Some(ident)
-            } else {
-                None
-            })
-        .collect();
 
+    let modifiers = parse_macro_input!(_attrs as syn::AttributeArgs);
     let mut impl_item = syn::parse2::<ImplItemMethod>(_input.into())
         .expect("Can't parse input of `modifiers` macro like a method.");
+
+    if impl_item.sig.inputs.is_empty() {
+        return (quote_spanned! {
+            impl_item.sig.inputs.span() =>
+                compile_error!("Modifiers can by applied only to method with first `self` argument.");
+        }).into();
+    }
+
+    let receiver;
+    if let syn::FnArg::Receiver(rec) = impl_item.sig.inputs.first().unwrap() {
+        receiver = rec;
+    } else {
+        return (quote_spanned! {
+            impl_item.sig.inputs.first().unwrap().span() =>
+                compile_error!("First argument in modifiers must be `self`.");
+        }).into();
+    }
 
     // We skip every function without body(it means that it contains only `{ ; }`)
     if impl_item.block.to_token_stream().to_string() == "{ ; }" {
@@ -38,39 +49,15 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
         return code.into();
     }
 
-    let locked_file = metadata::get_locked_file();
-    let metadata = metadata::Metadata::load(&locked_file);
-    metadata.save_and_unlock(locked_file);
+    let mut block = impl_item.block.clone();
+    let mut body_index = 0;
 
-    let local_function_ident = format_ident!("{}_local", impl_item.sig.ident);
-    let block = impl_item.block.clone();
-
-    // Put the body of original function to local lambda function
-    let mut final_stmts = syn::parse2::<syn::Block>(quote! {
-        {
-            let mut #local_function_ident = || #block;
+    let modifiers: Vec<_> = modifiers.into_iter().filter_map(|nested_meta| {
+        match nested_meta {
+            syn::NestedMeta::Meta(meta) => Some(meta),
+            _ => None,
         }
-    }).unwrap().stmts;
-
-    let has_return = impl_item.sig.output != syn::ReturnType::Default;
-
-    let return_ident = format_ident!("{}_out", local_function_ident);
-    let function_call;
-
-    if has_return {
-        function_call = syn::parse2::<syn::Block>(quote! {
-            {
-                let #return_ident = #local_function_ident();
-            }
-        }).unwrap().stmts;
-    } else {
-        function_call = syn::parse2::<syn::Block>(quote! {
-            {
-                #local_function_ident();
-            }
-        }).unwrap().stmts;
-    }
-    final_stmts.extend(function_call);
+    }).collect();
 
     // Code of each modifier must be added in reverse order
     // Code of first modifier {
@@ -80,31 +67,52 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
     //          }
     //      }
     // }
-    for modifier_ident in  modifiers.into_iter().rev() {
-        let modifier = metadata.modifiers.get(&modifier_ident.to_string());
+    for modifier_meta in  modifiers.into_iter().rev() {
+        // Replace every `self` with instance variable
+        block = replace_self(block);
 
-        let mut local_stmts = vec![];
-        for stmt in modifier.block.stmts.clone() {
-            if is_body_stmt(&stmt) {
-                // We found #[body]() statement, so we put body here
-                local_stmts.extend(final_stmts.clone());
-                continue;
-            }
-            local_stmts.push(stmt.clone());
+        // Put the body of original function to local lambda function
+        let (final_block, body_ident) = put_into_closure(receiver, block, body_index);
+        body_index += 1;
+
+        // It means modifiers without arguments, we can call path method directly.
+        if let syn::Meta::Path(method) = modifier_meta {
+            let stmts = final_block.stmts;
+            block = syn::parse2::<syn::Block>(quote! {
+                {
+                    #(#stmts)*
+                    #method(self, #body_ident)
+                }
+            }).unwrap();
+        } else if let syn::Meta::List(meta_list) = modifier_meta {
+            let method = meta_list.path;
+            let mut cloned_variables_idents = vec![];
+            let cloned_variables_definitions = meta_list.nested.iter()
+                .map(|nested_meta| {
+                    let cloned_ident = format_ident!("__brush_cloned_{}", cloned_variables_idents.len());
+                    cloned_variables_idents.push(cloned_ident.clone());
+                    quote! {
+                        let #cloned_ident = #nested_meta.clone();
+                    }
+                });
+
+            let stmts = final_block.stmts;
+            block = syn::parse2::<syn::Block>(quote! {
+                {
+                    #(#cloned_variables_definitions)*
+                    #(#stmts)*
+                    #method(self, #body_ident #(, #cloned_variables_idents )*)
+                }
+            }).unwrap();
+        } else {
+            return (quote_spanned! {
+                modifier_meta.span() =>
+                    compile_error!("Modifiers doesn't support MetaNameValue in arguments");
+            }).into();
         }
-        final_stmts = local_stmts;
     }
 
-    if has_return {
-        let return_value = syn::parse2::<syn::Block>(quote! {
-            {
-                return #return_ident;
-            }
-        }).unwrap().stmts;
-        final_stmts.extend(return_value);
-    }
-
-    impl_item.block.stmts = final_stmts;
+    impl_item.block = block;
 
     let code = quote! {
         #[cfg(not(feature = "ink-as-dependency"))]
@@ -117,18 +125,48 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
     code.into()
 }
 
-fn is_body_stmt(stmt: &syn::Stmt) -> bool {
-    match stmt {
-        syn::Stmt::Semi(expr, _) =>
-            match expr {
-                syn::Expr::Tuple(tuple) => is_attr(&tuple.attrs, "body"),
-                _ => false,
+fn replace_self(block: syn::Block) -> syn::Block {
+    syn::parse2::<syn::Block>(recursive_replace_self(block.to_token_stream())).unwrap()
+}
+
+fn recursive_replace_self(token_stream: TokenStream2) -> TokenStream2 {
+    token_stream.into_iter()
+        .map(|token| {
+            match &token {
+                TokenTree::Ident(ident) =>
+                    if ident.to_string() == "self" {
+                        TokenTree::Ident(format_ident!("{}", INSTANCE))
+                    } else {
+                        token
+                    },
+                TokenTree::Group(group) => {
+                    TokenTree::Group(
+                        proc_macro2::Group::new(
+                            group.delimiter(),
+                            recursive_replace_self(group.stream())
+                        )
+                    )
+                }
+                _ => token,
             }
-        syn::Stmt::Expr(expr) =>
-            match expr {
-                syn::Expr::Tuple(tuple) => is_attr(&tuple.attrs, "body"),
-                _ => false,
-            }
-        _ => false,
-    }
+        }).collect()
+}
+
+fn put_into_closure(receiver: &syn::Receiver, block: syn::Block, index: u8) -> (syn::Block, syn::Ident) {
+    let body_ident = format_ident!("__brush_body_{}", index);
+    let instance_ident = format_ident!("{}", INSTANCE);
+
+    let reference = match receiver.mutability.is_some() {
+        true => quote! { &mut },
+        false => quote! { & },
+    };
+
+    // Put the body of original function to local lambda function
+    let final_block = syn::parse2::<syn::Block>(quote! {
+        {
+            let mut #body_ident = |#instance_ident: #reference Self| #block;
+        }
+    }).unwrap();
+
+    (final_block, body_ident)
 }

--- a/contracts/brush/proc_macros/modifiers.rs
+++ b/contracts/brush/proc_macros/modifiers.rs
@@ -27,7 +27,7 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
     if impl_item.sig.inputs.is_empty() {
         return (quote_spanned! {
             impl_item.sig.inputs.span() =>
-                compile_error!("Modifiers can by applied only to method with first `self` argument.");
+                compile_error!("Modifiers can only be applied to method whose first argument is `self`. ");
         }).into();
     }
 

--- a/contracts/brush/proc_macros/modifiers.rs
+++ b/contracts/brush/proc_macros/modifiers.rs
@@ -37,7 +37,7 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
     } else {
         return (quote_spanned! {
             impl_item.sig.inputs.first().unwrap().span() =>
-                compile_error!("First argument in modifiers must be `self`.");
+                compile_error!("First argument in method must be `self`.");
         }).into();
     }
 

--- a/contracts/brush/proc_macros/modifiers.rs
+++ b/contracts/brush/proc_macros/modifiers.rs
@@ -27,7 +27,7 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
     if impl_item.sig.inputs.is_empty() {
         return (quote_spanned! {
             impl_item.sig.inputs.span() =>
-                compile_error!("Modifiers can only be applied to method whose first argument is `self`. ");
+                compile_error!("Modifiers can only be applied to methods, which have `self` as their first argument. ");
         }).into();
     }
 
@@ -107,7 +107,7 @@ pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream 
         } else {
             return (quote_spanned! {
                 modifier_meta.span() =>
-                    compile_error!("Modifiers doesn't support MetaNameValue in arguments");
+                    compile_error!("Modifiers don't support MetaNameValue in arguments");
             }).into();
         }
     }

--- a/contracts/security/reentrancy_guard/traits.rs
+++ b/contracts/security/reentrancy_guard/traits.rs
@@ -1,13 +1,13 @@
 pub use brush::{modifiers, modifier_definition};
 pub use ink_lang::{Env, StaticEnv};
 pub use reentrancy_guard_derive::ReentrancyGuardStorage;
-pub use brush::traits::Flush;
+use brush::traits::Flush;
 
 // We don't need to expose it, because ink! will define StaticEnv itself.
 use brush::traits::{InkStorage};
 
-pub const NOT_ENTERED: u8 = 0;
-pub const ENTERED: u8 = 1;
+const NOT_ENTERED: u8 = 0;
+const ENTERED: u8 = 1;
 
 #[brush::storage_trait]
 pub trait ReentrancyGuardStorage: InkStorage {
@@ -20,18 +20,22 @@ pub enum ReentrancyGuardError {
     ReentrantCall,
 }
 
-pub trait ReentrancyGuardModifier: ReentrancyGuardStorage + Flush {
-    #[modifier_definition]
-    fn non_reentrant(&mut self) {
-        assert_eq!(self._status(), &NOT_ENTERED, "{}", ReentrancyGuardError::ReentrantCall.as_ref());
-        // Any calls to nonReentrant after this point will fail
-        *self._status_mut() = ENTERED;
+#[modifier_definition]
+pub fn non_reentrant<T, F, ReturnType>(instance: &mut T, mut body: F) -> ReturnType
+    where
+        T: ReentrancyGuardStorage + Flush,
+        F: FnMut(&mut T) -> ReturnType,
+{
+    assert_eq!(instance._status(), &NOT_ENTERED, "{}", ReentrancyGuardError::ReentrantCall.as_ref());
+    // Any calls to nonReentrant after this point will fail
+    *instance._status_mut() = ENTERED;
 
-        // We want to flush storage before execution of inner function,
-        // because ink! doesn't do it by default and `status` will be not updated in child calls
-        self.flush();
+    // We want to flush storage before execution of inner function,
+    // because ink! doesn't do it by default and `status` will be not updated in child calls
+    instance.flush();
 
-        #[body]();
-        *self._status_mut() = NOT_ENTERED;
-    }
+    let result = body(instance);
+    *instance._status_mut() = NOT_ENTERED;
+
+    return result;
 }

--- a/contracts/security/reentrancy_guard/traits.rs
+++ b/contracts/security/reentrancy_guard/traits.rs
@@ -31,7 +31,7 @@ pub fn non_reentrant<T, F, ReturnType>(instance: &mut T, mut body: F) -> ReturnT
     *instance._status_mut() = ENTERED;
 
     // We want to flush storage before execution of inner function,
-    // because ink! doesn't do it by default and `status` will be not updated in child calls
+    // because ink! doesn't do it by default and `status` will not be updated in child calls
     instance.flush();
 
     let result = body(instance);

--- a/examples/access-control/lib.rs
+++ b/examples/access-control/lib.rs
@@ -14,6 +14,12 @@ pub mod my_access_control {
     // ::ink_lang_ir::Selector::new("MINTER".as_ref()).as_bytes()
     const MINTER: RoleType = 0xfd9ab216;
 
+    #[brush::modifier_definition]
+    pub fn only_minter(instance: &mut PSP721Struct, body: impl Fn(&mut PSP721Struct)) {
+        instance._check_role(&MINTER, &instance.env().caller());
+        body(instance)
+    }
+
     impl PSP721Struct {
         #[ink(constructor)]
         pub fn new() -> Self {
@@ -23,12 +29,6 @@ pub mod my_access_control {
             // We grant minter role to caller in constructor, so he can mint/burn tokens
             instance.grant_role(MINTER, caller);
             instance
-        }
-
-        #[brush::modifier_definition]
-        fn only_minter(&self) {
-            self._check_role(&MINTER, &self.env().caller());
-            #[body]()
         }
     }
 


### PR DESCRIPTION
Instead of copy/pasting the code from the modifier declaration. We will directly call the modifier's function on rust level.
The first argument is an instance of a contract. The second argument is the body code of function marked with a modifier.
Every next argument can be specified by the developer and past inside of the modifier.