### PR TITLE
Release v1.0.0

### DIFF
--- a/contracts/access/access-control/Cargo.toml
+++ b/contracts/access/access-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "access-control"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/access/access-control/derive/Cargo.toml
+++ b/contracts/access/access-control/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "access_control_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/access/ownable/Cargo.toml
+++ b/contracts/access/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ownable"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/access/ownable/derive/Cargo.toml
+++ b/contracts/access/ownable/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ownable_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/finance/payment-splitter/Cargo.toml
+++ b/contracts/finance/payment-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment-splitter"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/finance/payment-splitter/derive/Cargo.toml
+++ b/contracts/finance/payment-splitter/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "payment_splitter_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/governance/timelock-controller/Cargo.toml
+++ b/contracts/governance/timelock-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timelock-controller"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/governance/timelock-controller/derive/Cargo.toml
+++ b/contracts/governance/timelock-controller/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timelock_controller_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/security/pausable/Cargo.toml
+++ b/contracts/security/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pausable"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/security/pausable/derive/Cargo.toml
+++ b/contracts/security/pausable/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pausable_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/security/reentrancy-guard/Cargo.toml
+++ b/contracts/security/reentrancy-guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reentrancy_guard"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/security/reentrancy-guard/derive/Cargo.toml
+++ b/contracts/security/reentrancy-guard/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reentrancy_guard_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/token/psp1155/Cargo.toml
+++ b/contracts/token/psp1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp1155"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/token/psp1155/derive/Cargo.toml
+++ b/contracts/token/psp1155/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp1155_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/token/psp22/Cargo.toml
+++ b/contracts/token/psp22/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/token/psp22/derive/Cargo.toml
+++ b/contracts/token/psp22/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/token/psp721/Cargo.toml
+++ b/contracts/token/psp721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp721"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/token/psp721/derive/Cargo.toml
+++ b/contracts/token/psp721/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp721_derive"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/doc/src/examples/access-control.md
+++ b/doc/src/examples/access-control.md
@@ -21,9 +21,9 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-psp721 = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-access-control = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+psp721 = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+access-control = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/doc/src/examples/ownable.md
+++ b/doc/src/examples/ownable.md
@@ -21,9 +21,9 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-psp1155 = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-ownable = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+psp1155 = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+ownable = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/doc/src/examples/pausable.md
+++ b/doc/src/examples/pausable.md
@@ -20,8 +20,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-pausable = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+pausable = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/doc/src/examples/payment-splitter.md
+++ b/doc/src/examples/payment-splitter.md
@@ -20,8 +20,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-payment-splitter = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+payment-splitter = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 
 # payment-splitter uses dividing inside, so your version of rust can require you to disable check overflow.

--- a/doc/src/examples/psp22.md
+++ b/doc/src/examples/psp22.md
@@ -22,8 +22,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-psp22 = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+psp22 = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/doc/src/examples/reentrancy-guard.md
+++ b/doc/src/examples/reentrancy-guard.md
@@ -28,8 +28,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-reentrancy-guard = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+reentrancy-guard = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 crate-type = [
     "cdylib",

--- a/doc/src/examples/timelock-controller.md
+++ b/doc/src/examples/timelock-controller.md
@@ -20,8 +20,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-timelock-controller = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+timelock-controller = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,9 @@ This folder contains examples of how the library can be used & how to customize 
 * [ReentrancyGuard](reentrancy-guard) shows how you can use the implementation of
   [non_reentrant](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/security/reentrancy-guard)
   modifier to prevent reentrancy during certain functions.
+* [Pausable](pausable.md) shows how you can use the implementation of
+  [pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/security/pausable)
+  contract and modifiers.
 * [TimelockController](timelock-controller) shows how you can use the implementation of
   [timelock-controller](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/governance/timelock-controller)
   to execute a transaction with some delay via governance.

--- a/examples/access-control/Cargo.toml
+++ b/examples/access-control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_access_control"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/access-control/README.md
+++ b/examples/access-control/README.md
@@ -21,9 +21,9 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-psp721 = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-access-control = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+psp721 = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+access-control = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_ownable"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/ownable/README.md
+++ b/examples/ownable/README.md
@@ -21,9 +21,9 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-psp1155 = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-ownable = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+psp1155 = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+ownable = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_pausable"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/pausable/README.md
+++ b/examples/pausable/README.md
@@ -20,8 +20,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-pausable = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+pausable = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/examples/payment-splitter/Cargo.toml
+++ b/examples/payment-splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_payment_splitter"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/payment-splitter/README.md
+++ b/examples/payment-splitter/README.md
@@ -20,8 +20,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-payment-splitter = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+payment-splitter = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 
 # payment-splitter uses dividing inside, so your version of rust can require you to disable check overflow.

--- a/examples/psp22/Cargo.toml
+++ b/examples/psp22/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22/README.md
+++ b/examples/psp22/README.md
@@ -22,8 +22,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-psp22 = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+psp22 = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/examples/reentrancy-guard/README.md
+++ b/examples/reentrancy-guard/README.md
@@ -28,8 +28,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-reentrancy-guard = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+reentrancy-guard = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 crate-type = [
     "cdylib",

--- a/examples/reentrancy-guard/flip_on_me/Cargo.toml
+++ b/examples/reentrancy-guard/flip_on_me/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flip_on_me"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/reentrancy-guard/flipper/Cargo.toml
+++ b/examples/reentrancy-guard/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_flipper_guard"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/timelock-controller/Cargo.toml
+++ b/examples/timelock-controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_timelock_controller"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/timelock-controller/README.md
+++ b/examples/timelock-controller/README.md
@@ -20,8 +20,8 @@ scale = { package = "parity-scale-codec", version = "2.1", default-features = fa
 scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 # These dependencies
-timelock-controller = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
-brush = { tag = "v0.3.0-rc1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+timelock-controller = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.0.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/mock/psp1155-receiver/Cargo.toml
+++ b/mock/psp1155-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp1155_receiver"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/mock/psp22-receiver/Cargo.toml
+++ b/mock/psp22-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_receiver"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/mock/psp721-receiver/Cargo.toml
+++ b/mock/psp721-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp721_receiver"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/utils/brush/Cargo.toml
+++ b/utils/brush/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brush"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/utils/brush/proc_macros/Cargo.toml
+++ b/utils/brush/proc_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_macros"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/utils/brush_derive_macro/Cargo.toml
+++ b/utils/brush_derive_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brush_derive_macro"
-version = "0.3.0-rc1"
+version = "1.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 


### PR DESCRIPTION
- Implemented Advanced modifiers on Rust level.
- Redesigned storage traits. Instead of adding fields to the struct during compilation time via macro, the user must declare the corresponding data field in the storage struct and mark it with an attribute from the derive macro.
- Redesigned default implementation in traits. Now, the trait defined by the user is a simple rust trait. Our macro will generate separate "external" trait with `#[ink(message)]` and `#[ink(constrcutor)]`. This trait will have the name of the original trait + prefix. All methods in this trait also will be prefixed. But with [`metadata_name`](https://github.com/paritytech/ink/pull/859) attribute we will generate the same ABI.
- Added macros to generate a hash from the string during compilation time.
- Renamed IOwnable -> Ownable, IAccessControl -> AccessControl.
- Added new contracts: TimelockController, PaymentSplitter, ReentrancyGuard, and Pausable.
- Introduced a `Flush` trait supported by storage(if you are implementing the `InkStorage` trait).
- Renamed `PSP20` -> `PSP22`.
- Added/Updated/Extended/Fixed documentation. Created [GitHub Pages](https://supercolony-net.github.io/openbrush-contracts/).