### PR TITLE
Release OpenBrush v1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 
 [package]
 name = "brush"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -188,17 +188,6 @@ After you can run tests by `npm run test` command. It will build all contracts r
 
 ## FAQ
 
-### Why IntelliJ rust plugin doesn't autocomplete the library's derive macros?
-
-It requires enabling of several experimental features:
-
-* `org.rust.cargo.evaluate.build.scripts` - enables building and collecting build artefacts including proc-macro
-  libraries during importing of project structure
-* `org.rust.macros.proc` - enables expansion of procedural macros
-
-To enable an experimental feature, type `Experimental feature` in the dialog of `Help | Find Action` action and enabled
-the corresponding item.
-
 ### Was it audited?
 
 Contracts in this repository have not yet been audited. But it is in plans.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ this [issue](https://github.com/Supercolony-net/openbrush-contracts/issues/7)
 ------- Pre-release 2.0.0
 
 - [x] Finalize PSP for fungible tokens. Refactor of implementation.
+- [x] Agnostic traits.
+- [x] Wrapper around the trait definition to do a cross-contract calls.
 - [ ] PSPs for NFT and multi-token.
 - [ ] Add extensions: AccessControlEnumerable, ERC721Enumerable.
 - [ ] Refactor NFT and multi-token according to final decisions in PSPs.

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contracts"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/derive/Cargo.toml
+++ b/contracts/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/example_project_structure/Cargo.toml
+++ b/example_project_structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net, dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/example_project_structure/contracts/lending/Cargo.toml
+++ b/example_project_structure/contracts/lending/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_contract"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/example_project_structure/contracts/loan/Cargo.toml
+++ b/example_project_structure/contracts/loan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loan_contract"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/example_project_structure/contracts/shares/Cargo.toml
+++ b/example_project_structure/contracts/shares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shares_contract"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/example_project_structure/contracts/stable_coin/Cargo.toml
+++ b/example_project_structure/contracts/stable_coin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable_coin_contract"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/example_project_structure/derive/Cargo.toml
+++ b/example_project_structure/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project_derive"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/access_control/Cargo.toml
+++ b/examples/access_control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_access_control"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_ownable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_pausable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/payment_splitter/Cargo.toml
+++ b/examples/payment_splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_payment_splitter"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp1155/Cargo.toml
+++ b/examples/psp1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp1155_extensions/burnable/Cargo.toml
+++ b/examples/psp1155_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_burnable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp1155_extensions/metadata/Cargo.toml
+++ b/examples/psp1155_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_metadata"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp1155_extensions/mintable/Cargo.toml
+++ b/examples/psp1155_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_mintable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22/Cargo.toml
+++ b/examples/psp22/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/burnable/Cargo.toml
+++ b/examples/psp22_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_burnable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/capped/Cargo.toml
+++ b/examples/psp22_extensions/capped/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_capped"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/flashmint/Cargo.toml
+++ b/examples/psp22_extensions/flashmint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_flashmint"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/metadata/Cargo.toml
+++ b/examples/psp22_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/mintable/Cargo.toml
+++ b/examples/psp22_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_mintable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/pausable/Cargo.toml
+++ b/examples/psp22_extensions/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pausable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_extensions/wrapper/Cargo.toml
+++ b/examples/psp22_extensions/wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_wrapper"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp22_utils/token_timelock/Cargo.toml
+++ b/examples/psp22_utils/token_timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_token_timelock"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp721/Cargo.toml
+++ b/examples/psp721/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp721"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp721_extensions/burnable/Cargo.toml
+++ b/examples/psp721_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp721_burnable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp721_extensions/metadata/Cargo.toml
+++ b/examples/psp721_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp721_metadata"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/psp721_extensions/mintable/Cargo.toml
+++ b/examples/psp721_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp721_mintable"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/examples/reentrancy_guard/flip_on_me/Cargo.toml
+++ b/examples/reentrancy_guard/flip_on_me/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flip_on_me"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/reentrancy_guard/flipper/Cargo.toml
+++ b/examples/reentrancy_guard/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_flipper_guard"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/examples/timelock_controller/Cargo.toml
+++ b/examples/timelock_controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_timelock_controller"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/mock/flash-borrower/Cargo.toml
+++ b/mock/flash-borrower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash_borrower"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2018"
 

--- a/mock/psp1155-receiver/Cargo.toml
+++ b/mock/psp1155-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp1155_receiver"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/mock/psp22-receiver/Cargo.toml
+++ b/mock/psp22-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_receiver"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/mock/psp721-receiver/Cargo.toml
+++ b/mock/psp721-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp721_receiver"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/utils/brush_derive/Cargo.toml
+++ b/utils/brush_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brush_derive"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/utils/brush_lang/Cargo.toml
+++ b/utils/brush_lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brush_lang"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/utils/brush_lang/proc_macros/Cargo.toml
+++ b/utils/brush_lang/proc_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_macros"
-version = "1.0.0"
+version = "1.2.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 


### PR DESCRIPTION
- Implemented Agnostic traits - don't contain any stuff related to the implementation of the trait. 
- Created a new macro `brush::wrapper`. That macro allows defining a new type - wrapper around some trait. All methods that are marked with `#[ink(message)]` will generate in wrapper a code to do cross-contract calls. So now is enough to have a trait definition to do cross-contract calls.
- Created an example and updated documentation. The example shows how better to maintain the structure of the project and how you can split the logic to improve the readability.
- Configured the CI to run unit and integration tests.