### PR TITLE
Fix rust-analyser for VSCode

### DIFF
--- a/utils/brush_lang/proc_macros/contract.rs
+++ b/utils/brush_lang/proc_macros/contract.rs
@@ -14,6 +14,9 @@ use quote::{
 use syn::Item;
 
 pub(crate) fn generate(_attrs: TokenStream, ink_module: TokenStream) -> TokenStream {
+    if internal::skip() {
+        return (quote! {}).into()
+    }
     let input: TokenStream2 = ink_module.into();
     let attrs: TokenStream2 = _attrs.into();
     let mut module = syn::parse2::<syn::ItemMod>(input.clone()).expect("Can't parse contract module");

--- a/utils/brush_lang/proc_macros/internal.rs
+++ b/utils/brush_lang/proc_macros/internal.rs
@@ -290,3 +290,10 @@ pub(crate) fn extract_attr(attrs: &mut Vec<syn::Attribute>, ident: &str) -> Vec<
 pub(crate) fn new_attribute(attr_stream: TokenStream2) -> syn::Attribute {
     syn::parse2::<Attributes>(attr_stream).unwrap().attr()[0].clone()
 }
+
+pub(crate) const INK_PREFIX: &str = "ink_lang=";
+
+#[inline]
+pub(crate) fn skip() -> bool {
+    std::env::args().find(|arg| arg.contains(INK_PREFIX)).is_none()
+}

--- a/utils/brush_lang/proc_macros/metadata.rs
+++ b/utils/brush_lang/proc_macros/metadata.rs
@@ -123,15 +123,16 @@ pub(crate) enum LockType {
 /// Function returns exclusively locked file for metadata.
 /// It stores file in the target folder where `ink_lang` is stored.
 pub(crate) fn get_locked_file(t: LockType) -> File {
-    const PREFIX: &str = "ink_lang=";
+    use crate::internal::INK_PREFIX;
     const SUFFIX: &str = "target/";
+
     let target: String = env::args()
-        .find(|arg| arg.contains(PREFIX))
-        .expect("Unable to find PREFIX");
+        .find(|arg| arg.contains(INK_PREFIX))
+        .expect(format!("Unable to find PREFIX: {:?}", env::args()).as_str());
     let target: String = target
         .chars()
-        .skip(PREFIX.len())
-        .take(target.find(SUFFIX).expect("Unable to find debug/deps") - PREFIX.len() + SUFFIX.len())
+        .skip(INK_PREFIX.len())
+        .take(target.find(SUFFIX).expect("Unable to find debug/deps") - INK_PREFIX.len() + SUFFIX.len())
         .collect();
 
     let target_dir = Utf8PathBuf::from_str(target.as_str()).expect("Can't generate Path from target");

--- a/utils/brush_lang/proc_macros/trait_definition.rs
+++ b/utils/brush_lang/proc_macros/trait_definition.rs
@@ -20,6 +20,9 @@ use syn::{
 };
 
 pub(crate) fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
+    if crate::internal::skip() {
+        return (quote! {}).into()
+    }
     let attrs: proc_macro2::TokenStream = _attrs.into();
     let mut trait_item = parse_macro_input!(_input as ItemTrait);
     let trait_without_ink_attrs;


### PR DESCRIPTION
Don't run the macro if it is not ready to be expanded