### PR TITLE
A new release 1.6.1 with new ink 3.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 
 [package]
 name = "brush"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "contracts"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/contracts/derive/Cargo.toml
+++ b/contracts/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/docs/docs/smart-contracts/PSP1155/psp1155.md
+++ b/docs/docs/smart-contracts/PSP1155/psp1155.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP1155 via `brush` feature.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp1155"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp1155"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/capped.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/capped.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP22 via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP22 and Pausable via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22", "pausable"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22", "pausable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP22 via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
+++ b/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP22 via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/psp22.md
+++ b/docs/docs/smart-contracts/PSP22/psp22.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP22 via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
+++ b/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP34 via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp34"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp34"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP34/psp34.md
+++ b/docs/docs/smart-contracts/PSP34/psp34.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of PSP34 via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp34"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["psp34"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/access-control.md
+++ b/docs/docs/smart-contracts/access-control.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Access Control via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["access_control"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["access_control"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/diamond.md
+++ b/docs/docs/smart-contracts/diamond.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Diamond Standard via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["diamond"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["diamond"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/overview.md
+++ b/docs/docs/smart-contracts/overview.md
@@ -23,7 +23,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 # Brush dependency
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false }
 
 [features]
 default = ["std"]

--- a/docs/docs/smart-contracts/ownable.md
+++ b/docs/docs/smart-contracts/ownable.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Ownable via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["ownable"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["ownable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/pausable.md
+++ b/docs/docs/smart-contracts/pausable.md
@@ -12,7 +12,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Pausable via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["pausable"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["pausable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/payment-splitter.md
+++ b/docs/docs/smart-contracts/payment-splitter.md
@@ -12,7 +12,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Payment Splitter via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["payment_splitter"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["payment_splitter"] }
 
 # payment-splitter uses dividing inside, so your version of rust can require you to disable check overflow.
 [profile.dev]

--- a/docs/docs/smart-contracts/proxy.md
+++ b/docs/docs/smart-contracts/proxy.md
@@ -11,7 +11,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Proxy via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["proxy"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["proxy"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/reentrancy-guard.md
+++ b/docs/docs/smart-contracts/reentrancy-guard.md
@@ -20,7 +20,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Reentrancy Guard via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["reentrancy_guard"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["reentrancy_guard"] }
 ```
 
 ### Step 2: Add imports

--- a/docs/docs/smart-contracts/timelock-controller.md
+++ b/docs/docs/smart-contracts/timelock-controller.md
@@ -12,7 +12,7 @@ Include `brush` as dependency in the cargo file or you can use [default `Cargo.t
 After you need to enable default implementation of Timelock Controller via `brush` features.
 
 ```toml
-brush = { tag = "v1.6.0", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["timelock_controller"] }
+brush = { tag = "v1.6.1", git = "https://github.com/Supercolony-net/openbrush-contracts", default-features = false, features = ["timelock_controller"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/example_project_structure/Cargo.toml
+++ b/example_project_structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net, dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/lending/Cargo.toml
+++ b/example_project_structure/contracts/lending/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_contract"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/loan/Cargo.toml
+++ b/example_project_structure/contracts/loan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loan_contract"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/shares/Cargo.toml
+++ b/example_project_structure/contracts/shares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shares_contract"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/stable_coin/Cargo.toml
+++ b/example_project_structure/contracts/stable_coin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable_coin_contract"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/derive/Cargo.toml
+++ b/example_project_structure/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project_derive"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/access_control/Cargo.toml
+++ b/examples/access_control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_access_control"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/Cargo.toml
+++ b/examples/diamond/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_diamond"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/diamond_caller/Cargo.toml
+++ b/examples/diamond/diamond_caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diamond_caller"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_facet_v1/Cargo.toml
+++ b/examples/diamond/psp22_facet_v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_facet_v1"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_facet_v2/Cargo.toml
+++ b/examples/diamond/psp22_facet_v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_facet_v2"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_metadata_facet/Cargo.toml
+++ b/examples/diamond/psp22_metadata_facet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata_facet"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_ownable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_pausable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/payment_splitter/Cargo.toml
+++ b/examples/payment_splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_payment_splitter"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_proxy"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata_upgradeable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/psp22_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_upgradeable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155/Cargo.toml
+++ b/examples/psp1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155_extensions/burnable/Cargo.toml
+++ b/examples/psp1155_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_burnable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155_extensions/metadata/Cargo.toml
+++ b/examples/psp1155_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_metadata"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155_extensions/mintable/Cargo.toml
+++ b/examples/psp1155_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_mintable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22/Cargo.toml
+++ b/examples/psp22/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/burnable/Cargo.toml
+++ b/examples/psp22_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_burnable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/capped/Cargo.toml
+++ b/examples/psp22_extensions/capped/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_capped"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/flashmint/Cargo.toml
+++ b/examples/psp22_extensions/flashmint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_flashmint"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/metadata/Cargo.toml
+++ b/examples/psp22_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/mintable/Cargo.toml
+++ b/examples/psp22_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_mintable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/pausable/Cargo.toml
+++ b/examples/psp22_extensions/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pausable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/wrapper/Cargo.toml
+++ b/examples/psp22_extensions/wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_wrapper"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_utils/token_timelock/Cargo.toml
+++ b/examples/psp22_utils/token_timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_token_timelock"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34/Cargo.toml
+++ b/examples/psp34/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/burnable/Cargo.toml
+++ b/examples/psp34_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_burnable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/enumerable/Cargo.toml
+++ b/examples/psp34_extensions/enumerable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_enumerable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/metadata/Cargo.toml
+++ b/examples/psp34_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_metadata"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/mintable/Cargo.toml
+++ b/examples/psp34_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_mintable"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/Cargo.toml
+++ b/examples/reentrancy_guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flip_on_me"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/contracts/flipper/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_flipper_guard"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/timelock_controller/Cargo.toml
+++ b/examples/timelock_controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_timelock_controller"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/flash-borrower/Cargo.toml
+++ b/mock/flash-borrower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash_borrower"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp1155-receiver/Cargo.toml
+++ b/mock/psp1155-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp1155_receiver"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp22-receiver/Cargo.toml
+++ b/mock/psp22-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_receiver"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp34-receiver/Cargo.toml
+++ b/mock/psp34-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp34_receiver"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/utils/brush_derive/Cargo.toml
+++ b/utils/brush_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brush_derive"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/utils/brush_lang/Cargo.toml
+++ b/utils/brush_lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brush_lang"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/utils/brush_lang/proc_macros/Cargo.toml
+++ b/utils/brush_lang/proc_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proc_macros"
-version = "1.6.0"
+version = "1.6.1"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 


### PR DESCRIPTION
- Simplified running of unit tests.
- Speed up the build of the library by moving each trait definition to a separate file.
- Fixed the bug with modifiers that don't allow to have more than one input argument.
- Changed the name admin to member in `_setup_role` function=)
- Up version of ink! to 3.0.1
- Added additional test for `Diamond` and for `PSP34`