### PR TITLE
If someone sends `PSP34` token from `Alice` to `Alice` it breaks enumerable

### DIFF
--- a/contracts/tests/psp1155.rs
+++ b/contracts/tests/psp1155.rs
@@ -344,7 +344,7 @@ mod psp1155 {
         );
 
         assert!(nft
-            .batch_transfer_from(accounts.alice, accounts.bob, ids_amount.clone(), vec![],)
+            .batch_transfer_from(accounts.alice, accounts.bob, ids_amount.clone(), vec![])
             .is_ok());
 
         assert_eq!(

--- a/contracts/tests/psp22.rs
+++ b/contracts/tests/psp22.rs
@@ -240,7 +240,7 @@ mod psp22 {
         assert_eq!(emitted_events.len(), 2);
         // Check first transfer event related to PSP-20 instantiation.
         assert_transfer_event(&emitted_events[0], None, Some(AccountId::from([0x01; 32])), 100);
-        // Check the second transfer event relating to the actual trasfer.
+        // Check the second transfer event relating to the actual transfer.
         assert_transfer_event(
             &emitted_events[1],
             Some(AccountId::from([0x01; 32])),
@@ -304,9 +304,10 @@ mod psp22 {
         let emitted_events = ink_env::test::recorded_events().collect::<Vec<_>>();
         assert_eq!(emitted_events.len(), 4);
         assert_transfer_event(&emitted_events[0], None, Some(AccountId::from([0x01; 32])), 100);
-        // The second event `emitted_events[1]` is an Approve event that we skip checking.
+        // The second and third events (`emitted_events[1]` and `emitted_events[2]`) are an Approve event
+        // that we skip checking.
         assert_transfer_event(
-            &emitted_events[2],
+            &emitted_events[3],
             Some(AccountId::from([0x01; 32])),
             Some(AccountId::from([0x05; 32])),
             10,

--- a/contracts/tests/psp34_enumerable.rs
+++ b/contracts/tests/psp34_enumerable.rs
@@ -107,19 +107,25 @@ mod psp34_enumerable {
         let accounts = accounts();
         // Create a new contract instance.
         let mut nft = PSP34Struct::new();
-        // Create token Id 1 for Alice
+        // Create token Id 1 and Id 2 for Alice
         assert!(nft._mint_to(accounts.alice, Id::U8(1u8)).is_ok());
+        assert!(nft._mint_to(accounts.alice, Id::U8(2u8)).is_ok());
         // check Alice token by index
         assert_eq!(nft.owners_token_by_index(accounts.alice, 0u128), Ok(Id::U8(1u8)));
         // act. transfer token from alice to bob
         assert!(nft.transfer(accounts.bob, Id::U8(1u8), vec![]).is_ok());
         // bob owns token
         assert_eq!(nft.owners_token_by_index(accounts.bob, 0u128), Ok(Id::U8(1u8)));
-        // alice does not own token
+        // alice does not own token Id 1
+        assert_eq!(nft.owners_token_by_index(accounts.alice, 0u128), Ok(Id::U8(2u8)));
         assert_eq!(
-            nft.owners_token_by_index(accounts.alice, 0u128),
+            nft.owners_token_by_index(accounts.alice, 1u128),
             Err(PSP34Error::TokenNotExists)
         );
+        // act. transfer token from alice to alice
+        assert!(nft.transfer(accounts.alice, Id::U8(2u8), vec![]).is_ok());
+        // check Alice token by index
+        assert_eq!(nft.owners_token_by_index(accounts.alice, 0u128), Ok(Id::U8(2u8)));
     }
 
     #[ink::test]

--- a/contracts/token/psp22/psp22.rs
+++ b/contracts/token/psp22/psp22.rs
@@ -95,8 +95,8 @@ impl<T: PSP22Storage + Flush> PSP22 for T {
             return Err(PSP22Error::InsufficientAllowance)
         }
 
-        self._transfer_from_to(from, to, value, data)?;
         self._approve_from_to(from, caller, allowance - value)?;
+        self._transfer_from_to(from, to, value, data)?;
         Ok(())
     }
 
@@ -230,10 +230,13 @@ impl<T: PSP22Storage + Flush> PSP22Internal for T {
 
         self._before_token_transfer(Some(&from), Some(&to), &amount)?;
 
-        self._do_safe_transfer_check(&from, &to, &amount, &data)?;
         self.get_mut().balances.insert(&from, &(from_balance - amount));
+
+        self._do_safe_transfer_check(&from, &to, &amount, &data)?;
+
         let to_balance = self._balance_of(&to);
         self.get_mut().balances.insert(&to, &(to_balance + amount));
+
         self._after_token_transfer(Some(&from), Some(&to), &amount)?;
         self._emit_transfer_event(Some(from), Some(to), amount);
 

--- a/contracts/token/psp34/extensions/enumerable.rs
+++ b/contracts/token/psp34/extensions/enumerable.rs
@@ -88,6 +88,10 @@ impl<T: PSP34EnumerableStorage + Flush> PSP34EnumerableInternal for T {
         to: Option<&AccountId>,
         id: &Id,
     ) -> Result<(), PSP34Error> {
+        if from == to {
+            return Ok(())
+        }
+
         if from.is_none() {
             let last_free_index = self._total_supply();
             PSP34EnumerableStorage::get_mut(self)

--- a/contracts/token/psp34/psp34.rs
+++ b/contracts/token/psp34/psp34.rs
@@ -190,19 +190,17 @@ impl<T: PSP34Storage + Flush> PSP34Internal for T {
     default fn _transfer_token(&mut self, to: AccountId, id: Id, data: Vec<u8>) -> Result<(), PSP34Error> {
         let owner = self._check_token_exists(&id)?;
         let caller = Self::env().caller();
-        let id = Some(id);
+        let id_opt = Some(id.clone());
 
-        if owner != caller && !self._allowance(&owner, &caller, &id) {
+        if owner != caller && !self._allowance(&owner, &caller, &id_opt) {
             return Err(PSP34Error::NotApproved)
         }
 
-        self.get_mut().operator_approvals.remove((&owner, &caller, &id));
-
-        let id = id.unwrap();
-
         self._before_token_transfer(Some(&owner), Some(&to), &id)?;
 
+        self.get_mut().operator_approvals.remove((&owner, &caller, &id_opt));
         self._remove_token(&owner, &id)?;
+
         self._do_safe_transfer_check(&caller, &owner, &to, &id, &data)?;
         self._add_token(&to, &id)?;
         self._after_token_transfer(Some(&owner), Some(&to), &id)?;


### PR DESCRIPTION
If someone sends a `PSP34` token from `Alice` to `Alice` it breaks enumerable
Reduced the amount of tokens and allowance before calling the `before_received` method to prevent different attacks.