### PR TITLE
Payment Splitter release_all()

### DIFF
--- a/contracts/finance/payment_splitter/mod.rs
+++ b/contracts/finance/payment_splitter/mod.rs
@@ -162,7 +162,6 @@ impl<T: PaymentSplitterStorage> PaymentSplitterInternal for T {
         Ok(())
     }
 
-    #[ink(message)]
     default fn _release_all(&mut self) -> Result<(), PaymentSplitterError> {
         let payees = self.get().payees.clone();
 

--- a/contracts/finance/payment_splitter/mod.rs
+++ b/contracts/finance/payment_splitter/mod.rs
@@ -168,9 +168,10 @@ impl<T: PaymentSplitterStorage> PaymentSplitterInternal for T {
     }
 
     default fn _release_all(&mut self) -> Result<(), PaymentSplitterError> {
-        let payees = self.get().payees.clone();
+        let len = self.get().payees.len();
 
-        for account in payees.into_iter() {
+        for i in 0..len {
+            let account = self.get().payees[i];
             self.release(account)?;
         }
 

--- a/contracts/finance/payment_splitter/mod.rs
+++ b/contracts/finance/payment_splitter/mod.rs
@@ -162,6 +162,7 @@ impl<T: PaymentSplitterStorage> PaymentSplitterInternal for T {
         Ok(())
     }
 
+    #[ink(message)]
     default fn _release_all(&mut self) -> Result<(), PaymentSplitterError> {
         let payees = self.get().payees.clone();
 

--- a/contracts/finance/payment_splitter/mod.rs
+++ b/contracts/finance/payment_splitter/mod.rs
@@ -22,7 +22,12 @@
 pub use crate::traits::payment_splitter::*;
 use brush::{
     declare_storage_trait,
-    traits::{AccountId, AccountIdExt, Balance, ZERO_ADDRESS},
+    traits::{
+        AccountId,
+        AccountIdExt,
+        Balance,
+        ZERO_ADDRESS,
+    },
 };
 pub use derive::PaymentSplitterStorage;
 use ink_prelude::vec::Vec;
@@ -74,7 +79,7 @@ impl<T: PaymentSplitterStorage> PaymentSplitter for T {
 
     default fn release(&mut self, account: AccountId) -> Result<(), PaymentSplitterError> {
         if !self.get().shares.get(&account).is_some() {
-            return Err(PaymentSplitterError::AccountHasNoShares);
+            return Err(PaymentSplitterError::AccountHasNoShares)
         }
 
         let balance = Self::env().balance();
@@ -86,7 +91,7 @@ impl<T: PaymentSplitterStorage> PaymentSplitter for T {
         let payment = total_received * shares / total_shares - released;
 
         if payment == 0 {
-            return Err(PaymentSplitterError::AccountIsNotDuePayment);
+            return Err(PaymentSplitterError::AccountIsNotDuePayment)
         }
 
         self.get_mut().released.insert(&account, &(released + payment));
@@ -94,7 +99,7 @@ impl<T: PaymentSplitterStorage> PaymentSplitter for T {
 
         let transfer_result = Self::env().transfer(account.clone(), payment);
         if transfer_result.is_err() {
-            return Err(PaymentSplitterError::TransferFailed);
+            return Err(PaymentSplitterError::TransferFailed)
         }
         self._emit_payment_released_event(account, payment);
         Ok(())
@@ -135,7 +140,7 @@ impl<T: PaymentSplitterStorage> PaymentSplitterInternal for T {
 
     default fn _init(&mut self, payees_and_shares: Vec<(AccountId, Balance)>) -> Result<(), PaymentSplitterError> {
         if payees_and_shares.is_empty() {
-            return Err(PaymentSplitterError::NoPayees);
+            return Err(PaymentSplitterError::NoPayees)
         }
 
         for (payee, share) in payees_and_shares.into_iter() {
@@ -146,13 +151,13 @@ impl<T: PaymentSplitterStorage> PaymentSplitterInternal for T {
 
     default fn _add_payee(&mut self, payee: AccountId, share: Balance) -> Result<(), PaymentSplitterError> {
         if payee.is_zero() {
-            return Err(PaymentSplitterError::AccountZeroAddress);
+            return Err(PaymentSplitterError::AccountZeroAddress)
         }
         if share == 0 {
-            return Err(PaymentSplitterError::SharesAreZero);
+            return Err(PaymentSplitterError::SharesAreZero)
         }
         if self.get().shares.get(&payee).is_some() {
-            return Err(PaymentSplitterError::AlreadyHasShares);
+            return Err(PaymentSplitterError::AlreadyHasShares)
         }
 
         self.get_mut().payees.push(payee.clone());

--- a/contracts/tests/payment_splitter.rs
+++ b/contracts/tests/payment_splitter.rs
@@ -28,7 +28,10 @@ mod payment_splitter {
     use ink_lang as ink;
     use ink_storage::traits::SpreadAllocate;
 
-    use ink::codegen::{EmitEvent, Env};
+    use ink::codegen::{
+        EmitEvent,
+        Env,
+    };
 
     #[ink(event)]
     pub struct PayeeAdded {

--- a/examples/payment_splitter/README.md
+++ b/examples/payment_splitter/README.md
@@ -9,7 +9,8 @@ an amount proportional to the percentage of total shares they were assigned.
 
 `PaymentSplitter` follows a _pull payment_ model. This means that payments are not automatically forwarded to the
 accounts but kept in this contract, and the actual transfer is triggered as a separate step by calling the `release`
-function.
+function. `release` pays out to only the provided address. If you will have many people to pay out, especially if often, you will likely
+want to use the `releaseAll` method instead to save you a lot of time.
 
 ** Note **: In the substrate balance of contract decreases each block. Because it pays rent for the storage.
 So during `release`, each next user will get fewer native tokens.

--- a/examples/payment_splitter/lib.rs
+++ b/examples/payment_splitter/lib.rs
@@ -21,6 +21,13 @@ pub mod my_payment_splitter {
                 instance._init(payees_and_shares).expect("Should init");
             })
         }
+
+        /// Payout all payees at once.
+        /// Delete this method if you don't want this functionality in your version of the payment splitter.
+        #[ink(message)]
+        pub fn release_all(&mut self) -> Result<(), PaymentSplitterError> {
+            self._release_all()
+        }
     }
 
     impl PaymentSplitter for SplitterStruct {}

--- a/examples/payment_splitter/lib.rs
+++ b/examples/payment_splitter/lib.rs
@@ -26,6 +26,7 @@ pub mod my_payment_splitter {
         /// Delete this method if you don't want this functionality in your version of the payment splitter.
         #[ink(message)]
         pub fn release_all(&mut self) -> Result<(), PaymentSplitterError> {
+            // `_release_all()` is an internal method defined by the `PaymentSplitterInternal` trait
             self._release_all()
         }
     }

--- a/tests/payment-splitter.tests.ts
+++ b/tests/payment-splitter.tests.ts
@@ -49,4 +49,26 @@ describe('MY_PAYMENT_SPLITTER', () => {
     expect(ianReleased).to.equal(totalReleased * IAN_SHARE / (KAYNE_SHARE + IAN_SHARE))
     expect(ianReleased + kayneReleased).to.equal(totalReleased)
   })
+
+  it('PAYMENT SPLITTER - release a native token using releaseAll function', async () => {
+    // Arrange - Create a contract
+    const { contract, kayne, ian } = await setup()
+
+    // Act - Send native token and release them
+    await expect(contract.contract.query.totalReleased()).to.have.output(0)
+    await expect(contract.contract.tx.receive({ value: 1000000000000 })).to.eventually.be.fulfilled
+    await expect(contract.contract.tx.releaseAll()).to.eventually.be.fulfilled
+
+    // Assert - Ian must hold more tokens than kayne
+    // @ts-ignore
+    let totalReleased = Number.parseInt((await contract.contract.query.totalReleased()).output)
+    // @ts-ignore
+    let kayneReleased = Number.parseInt((await contract.contract.query.released(kayne.address)).output)
+    // @ts-ignore
+    let ianReleased = Number.parseInt((await contract.contract.query.released(ian.address)).output)
+    expect(ianReleased > kayneReleased).to.true
+    expect(kayneReleased).to.equal(totalReleased * KAYNE_SHARE / (KAYNE_SHARE + IAN_SHARE))
+    expect(ianReleased).to.equal(totalReleased * IAN_SHARE / (KAYNE_SHARE + IAN_SHARE))
+    expect(ianReleased + kayneReleased).to.equal(totalReleased)
+  })
 })


### PR DESCRIPTION
The main reason people use a payment splitter is to save time and make their life easier. I found this contract to be missing the crucial function that 90+% of users will want, which is a function to payout everyone at once. This way there is no copy/pasting addresses for a bi-weekly payout for each of your 15 DAO members and manually calling the `release` function over and over.

So I wrote a method that simply loops through the `payees` vector and calls the `release` method for each `AccountId`. This essentially automates the manual work the user would have to do with the `release` method.

I have 
- Updated the `PaymentSplitterInternal` trait with a `_release_all` method and given it a default implementation.
- Written a `correct_release_all` test.
- Updated the payment splitter readme.
- Added the `release_all` method (which calls the internal `_release_all`) to the payment splitter example as the vast majority of users will want this functionality from the start.

I would've tried to update the tutorial page (https://docs.openbrush.io/smart-contracts/payment-splitter/#step-5-define-constructor) as well but I didn't see the OpenBrush website repository as public.

I have tested the `release_all` method via polkadot.js with a locally running substrate-contracts-node and everything worked as expected.

Looks like my rust-analyzer extension changed formatting in a few places but that shouldn't be a problem.

Feedback on this is appreciated!

p.s. Wasn't sure if I should set this to merge directly to main branch or a new feature branch