### PR TITLE
Major release 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 
 [package]
 name = "openbrush"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 
@@ -37,8 +37,8 @@ ink_prelude = { version = "~3.2.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-openbrush_contracts = { version = "~1.8.0", path = "contracts", default-features = false }
-openbrush_lang = { version = "~1.8.0", path = "lang", default-features = false }
+openbrush_contracts = { version = "~2.0.0", path = "contracts", default-features = false }
+openbrush_lang = { version = "~2.0.0", path = "lang", default-features = false }
 
 [lib]
 name = "openbrush"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_contracts"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -25,8 +25,8 @@ ink_prelude = { version = "~3.2.0", default-features = false }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-derive = { package = "openbrush_contracts_derive", version = "1.8.0", path = "derive" }
-openbrush = { version = "~1.8.0", package = "openbrush_lang", path = "../lang", default-features = false }
+derive = { package = "openbrush_contracts_derive", version = "~2.0.0", path = "derive" }
+openbrush = { version = "~2.0.0", package = "openbrush_lang", path = "../lang", default-features = false }
 
 [lib]
 name = "openbrush_contracts"

--- a/contracts/derive/Cargo.toml
+++ b/contracts/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_contracts_derive"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "lib.rs"]
 syn = { version = "1.0" }
 quote = "1.0"
 proc-macro2 = "1"
-openbrush = { package = "openbrush_lang", version = "1.8.0", path = "../../lang" }
+openbrush = { package = "openbrush_lang", version = "~2.0.0", path = "../../lang" }
 
 [lib]
 name = "openbrush_contracts_derive"

--- a/docs/docs/smart-contracts/PSP1155/Extensions/burnable.md
+++ b/docs/docs/smart-contracts/PSP1155/Extensions/burnable.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 title: PSP1155 Burnable
 ---
 
-This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155) token with [PSP1155Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155/src/extensions/burnable.rs) extension.
+This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155) token with [PSP1155Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155/src/extensions/burnable.rs) extension.
 
 ## How to use this extension
 
@@ -16,6 +16,6 @@ impl PSP1155Burnable for MyPSP1155 {}
 ```
 
 And that's it! Your `PSP1155` is now extended by the `PSP1155Burnable` extension and ready to use its functions!
-You can check an example of the usage of [PSP1155 Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp1155_extensions/burnable).
+You can check an example of the usage of [PSP1155 Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp1155_extensions/burnable).
 
 You can also check the documentation for the basic implementation of [PSP1155](/smart-contracts/PSP1155).

--- a/docs/docs/smart-contracts/PSP1155/Extensions/metadata.md
+++ b/docs/docs/smart-contracts/PSP1155/Extensions/metadata.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP1155 Metadata
 ---
 
-This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155) token with [PSP1155Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155/src/extensions/metadata.rs) extension.
+This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155) token with [PSP1155Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155/src/extensions/metadata.rs) extension.
 
 ## Step 1: Add imports and enable unstable feature
 
@@ -61,6 +61,6 @@ impl MyPSP1155 {
     }
 }
 ```
-You can check an example of the usage of [PSP1155 Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp1155_extensions/metadata).
+You can check an example of the usage of [PSP1155 Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp1155_extensions/metadata).
 
 You can also check the documentation for the basic implementation of [PSP1155](/smart-contracts/PSP1155).

--- a/docs/docs/smart-contracts/PSP1155/Extensions/mintable.md
+++ b/docs/docs/smart-contracts/PSP1155/Extensions/mintable.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: PSP1155 Mintable
 ---
 
-This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155) token with [PSP1155Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155/src/extensions/mintable.rs) extension.
+This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155) token with [PSP1155Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155/src/extensions/mintable.rs) extension.
 
 ## How to use this extension
 
@@ -16,6 +16,6 @@ impl PSP1155Mintable for MyPSP1155 {}
 ```
 
 And that's it! Your `PSP1155` is now extended by the `PSP1155Mintable` extension and ready to use its functions!
-You can check an example of the usage of [PSP1155 Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp1155_extensions/mintable).
+You can check an example of the usage of [PSP1155 Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp1155_extensions/mintable).
 
 You can also check the documentation for the basic implementation of [PSP1155](/smart-contracts/PSP1155).

--- a/docs/docs/smart-contracts/PSP1155/psp1155.md
+++ b/docs/docs/smart-contracts/PSP1155/psp1155.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP1155 via `openbrush` feature.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp1155"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp1155"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP1155/psp1155.md
+++ b/docs/docs/smart-contracts/PSP1155/psp1155.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP1155
 ---
 
-This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155) token. Also, this example shows how you can customize the logic, for example, to track the number of token types with `unique_ids`, adding a new token type with the `add_type` function.
+This example shows how you can reuse the implementation of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155) token. Also, this example shows how you can customize the logic, for example, to track the number of token types with `unique_ids`, adding a new token type with the `add_type` function.
 
 ## Step 1: Include dependencies
 
@@ -108,7 +108,7 @@ impl MyPSP1155 {
     }
 }
 ```
-You can check an example of the usage of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp1155).
+You can check an example of the usage of [PSP1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp1155).
 
 Also you can use extensions for PSP1155 token:
 

--- a/docs/docs/smart-contracts/PSP22/Extensions/burnable.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/burnable.md
@@ -4,7 +4,7 @@ title: PSP22 Burnable
 ---
 
 This example shows how you can reuse the implementation of
-[PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) token with [PSP22Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22/src/extensions/burnable.rs) extension.
+[PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) token with [PSP22Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22/src/extensions/burnable.rs) extension.
 
 ## How to use this extension
 
@@ -17,6 +17,6 @@ impl PSP22Burnable for MyPSP22 {}
 ```
 
 And that's it! Your `PSP22` is now extended by the `PSP22Burnable` extension and ready to use its functions!
-You can check an example of the usage of [PSP22 Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/burnable).
+You can check an example of the usage of [PSP22 Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/burnable).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/Extensions/capped.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/capped.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/capped.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/capped.md
@@ -3,7 +3,7 @@ sidebar_position: 7
 title: PSP22 Capped
 ---
 
-This example shows how you can implement a [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) contract with a supply cap, analogue to [ERC20Capped](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Capped.sol).
+This example shows how you can implement a [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) contract with a supply cap, analogue to [ERC20Capped](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/ERC20Capped.sol).
 
 ## Step 1: Include dependencies
 
@@ -94,6 +94,6 @@ impl MyPSP22Capped {
 }
 ```
 
-You can check an implementation example of [PSP22 Capped](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/capped).
+You can check an implementation example of [PSP22 Capped](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/capped).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/Extensions/flashmint.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/flashmint.md
@@ -3,7 +3,7 @@ sidebar_position: 5
 title: PSP22 FlashMint
 ---
 
-This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) token with [PSP22FlashMint](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22/extensions/flashmint.rs) extension, which allows the user to perform a flash loan on the token by minting the borrowed amount and then burning it along with fees for the loan.
+This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) token with [PSP22FlashMint](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22/extensions/flashmint.rs) extension, which allows the user to perform a flash loan on the token by minting the borrowed amount and then burning it along with fees for the loan.
 
 ## 1. Implement the FlashMint extension
 
@@ -16,6 +16,6 @@ impl FlashLender for MyPSP22FlashMint {}
 ```
 
 And that's it! Your `PSP22` is now extended by the `PSP22FlashMint` extension and ready to use its functions!
-You can check the full example of the implementation of this extension [here](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/flashmint).
+You can check the full example of the implementation of this extension [here](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/flashmint).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/Extensions/metadata.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/metadata.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP22 Metadata
 ---
 
-This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) token with the [PSP22Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22/src/extensions/metadata.rs) extension.
+This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) token with the [PSP22Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22/src/extensions/metadata.rs) extension.
 
 ## Step 1: Add imports and enable unstable feature
 
@@ -67,6 +67,6 @@ impl MyPSP22 {
 }
 ```
 
-You can check an example of the usage of [PSP22 Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/metadata).
+You can check an example of the usage of [PSP22 Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/metadata).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/Extensions/mintable.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/mintable.md
@@ -4,7 +4,7 @@ title: PSP22 Mintable
 ---
 
 This example shows how you can reuse the implementation of
-[PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) token with [PSP22Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22/src/extensions/mintable.rs) extension.
+[PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) token with [PSP22Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22/src/extensions/mintable.rs) extension.
 
 ## How to use this extension
 
@@ -16,7 +16,7 @@ use openbrush::contracts::psp22::extensions::mintable::*;
 impl PSP22Mintable for MyPSP22 {}
 ```
 
-You can check an example of the usage of [PSP22 Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/mintable).
+You can check an example of the usage of [PSP22 Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/mintable).
 
 And that's it! Your `PSP22` is now extended by the `PSP22Mintable` extension and ready to use its functions!
 

--- a/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 and Pausable via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp22", "pausable"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp22", "pausable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
@@ -3,7 +3,7 @@ sidebar_position: 6
 title: PSP22 Pausable
 ---
 
-This example shows how you can implement a [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) contract with a [Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/security/pausable) extension. See an example of [PSP22Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/pausable) implementation.
+This example shows how you can implement a [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) contract with a [Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/security/pausable) extension. See an example of [PSP22Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/pausable) implementation.
 
 ## Step 1: Include dependencies
 
@@ -98,6 +98,6 @@ impl MyPSP22Pausable {
 }
 ```
 
-You can check an implementation example of [PSP22 Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/pausable).
+You can check an implementation example of [PSP22 Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/pausable).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 title: PSP22 Wrapper
 ---
 
-This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) token with [PSP22 Wrapper](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22/extensions/wrapper.rs) extension, which allows you to wrap your `PSP22` token in a `PSP22Wrapper` token which can be used for example for governance.
+This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) token with [PSP22 Wrapper](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22/extensions/wrapper.rs) extension, which allows you to wrap your `PSP22` token in a `PSP22Wrapper` token which can be used for example for governance.
 
 ## Step 1: Include dependencies
 
@@ -69,6 +69,6 @@ impl MyPSP22 {
 }
 ```
 
-You can check an example of the usage of [PSP22 Wrapper](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_extensions/wrapper).
+You can check an example of the usage of [PSP22 Wrapper](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_extensions/wrapper).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
+++ b/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
+++ b/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP22 Token Timelock
 ---
 
-This example shows how you can reuse the implementation of [PSP22 Token Timelock](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22/src/utils/token_timelock.rs) utility for [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22). This contract will lock user's `PSP22` tokens until the time specified, when they can withdraw them.
+This example shows how you can reuse the implementation of [PSP22 Token Timelock](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22/src/utils/token_timelock.rs) utility for [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22). This contract will lock user's `PSP22` tokens until the time specified, when they can withdraw them.
 
 ## Step 1: Include dependencies
 
@@ -65,6 +65,6 @@ impl MyPSP22TokenTimelock {
 }
 ```
 
-You can check an example of the usage of [PSP22 Token Timelock](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22_utils/token_timelock).
+You can check an example of the usage of [PSP22 Token Timelock](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22_utils/token_timelock).
 
 You can also check the documentation for the basic implementation of [PSP22](/smart-contracts/PSP22).

--- a/docs/docs/smart-contracts/PSP22/psp22.md
+++ b/docs/docs/smart-contracts/PSP22/psp22.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP22
 ---
 
-This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22) token. Also, this example shows how you can customize the logic, for example, to reject transferring tokens to `hated_account`.
+This example shows how you can reuse the implementation of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22) token. Also, this example shows how you can customize the logic, for example, to reject transferring tokens to `hated_account`.
 
 ## Step 1: Include dependencies
 
@@ -122,7 +122,7 @@ impl MyPSP22 {
 }
 ```
 
-You can check an example of the usage of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp22).
+You can check an example of the usage of [PSP22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp22).
 
 Also you can use extensions for PSP22 token:
 

--- a/docs/docs/smart-contracts/PSP22/psp22.md
+++ b/docs/docs/smart-contracts/PSP22/psp22.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP34/Extensions/burnable.md
+++ b/docs/docs/smart-contracts/PSP34/Extensions/burnable.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 title: PSP34 Burnable
 ---
 
-This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34) token with [PSP34Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34/src/extensions/burnable.rs) extension.
+This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34) token with [PSP34Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34/src/extensions/burnable.rs) extension.
 
 ## How to use this extension
 
@@ -16,6 +16,6 @@ impl PSP34Burnable for MyPSP34 {}
 ```
 
 And that's it! Your `PSP34` is now extended by the `PSP34Burnable` extension and ready to use its functions!
-You can check an example of the usage of [PSP34 Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp34_extensions/burnable).
+You can check an example of the usage of [PSP34 Burnable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp34_extensions/burnable).
 
 You can also check the documentation for the basic implementation of [PSP34](/smart-contracts/PSP34).

--- a/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
+++ b/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP34 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp34"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp34"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
+++ b/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP34 Metadata
 ---
 
-This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34) token with [PSP34Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34/src/extensions/metadata.rs) extension.
+This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34) token with [PSP34Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34/src/extensions/metadata.rs) extension.
 
 ## Step 1: Include dependencies
 
@@ -73,6 +73,6 @@ impl MyPSP34 {
 }
 ```
 
-You can check an example of the usage of [PSP34 Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp34_extensions/metadata).
+You can check an example of the usage of [PSP34 Metadata](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp34_extensions/metadata).
 
 You can also check the documentation for the basic implementation of [PSP34](/smart-contracts/PSP34).

--- a/docs/docs/smart-contracts/PSP34/Extensions/mintable.md
+++ b/docs/docs/smart-contracts/PSP34/Extensions/mintable.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: PSP34 Mintable
 ---
 
-This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34) token with [PSP34Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34/src/extensions/mintable.rs) extension.
+This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34) token with [PSP34Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34/src/extensions/mintable.rs) extension.
 
 ## How to use this extension
 
@@ -16,6 +16,6 @@ impl PSP34Mintable for MyPSP34 {}
 ```
 
 And that's it! Your `PSP34` is now extended by the `PSP34Mintable` extension and ready to use its functions!
-You can check an example of the usage of [PSP34 Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp34_extensions/mintable).
+You can check an example of the usage of [PSP34 Mintable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp34_extensions/mintable).
 
 You can also check the documentation for the basic implementation of [PSP34](/smart-contracts/PSP34).

--- a/docs/docs/smart-contracts/PSP34/psp34.md
+++ b/docs/docs/smart-contracts/PSP34/psp34.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: PSP34
 ---
 
-This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34) token. Also, this example shows how you can customize the logic, for example, to track the number of tokens minted with `next_id`, increasing it with each new token minted, securing a unique id for each token.
+This example shows how you can reuse the implementation of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34) token. Also, this example shows how you can customize the logic, for example, to track the number of tokens minted with `next_id`, increasing it with each new token minted, securing a unique id for each token.
 
 ## Step 1: Include dependencies
 
@@ -93,7 +93,7 @@ impl MyPSP34 {
 }
 ```
 
-You can check an example of the usage of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/psp34).
+You can check an example of the usage of [PSP34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/psp34).
 Also you can use extensions for psp34 token:
 
 [PSP34Metadata](/smart-contracts/PSP34/extensions/metadata): metadata for PSP34.

--- a/docs/docs/smart-contracts/PSP34/psp34.md
+++ b/docs/docs/smart-contracts/PSP34/psp34.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP34 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["psp34"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp34"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/access-control.md
+++ b/docs/docs/smart-contracts/access-control.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Access Control via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["access_control"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["access_control"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/access-control.md
+++ b/docs/docs/smart-contracts/access-control.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: Access Control
 ---
 
-This example shows how you can use the implementation of [access-control](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/access/access_control) to provide rights for usage of specific smart contract functions.
+This example shows how you can use the implementation of [access-control](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/access/access_control) to provide rights for usage of specific smart contract functions.
 
 ## Step 1: Include dependencies
 
@@ -118,4 +118,4 @@ pub mod my_access_control {
 }
 ```
 
-You can check an example of the usage of [Access Control](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/access_control).
+You can check an example of the usage of [Access Control](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/access_control).

--- a/docs/docs/smart-contracts/diamond.md
+++ b/docs/docs/smart-contracts/diamond.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Diamond Standard via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["diamond"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["diamond"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/diamond.md
+++ b/docs/docs/smart-contracts/diamond.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 title: Diamond Standard
 ---
 
-This example shows how you can use the implementation of [diamond standard](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/upgradability/diamond) to implement diamond standard pattern for upgradeable and unlimited contracts.
+This example shows how you can use the implementation of [diamond standard](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/upgradability/diamond) to implement diamond standard pattern for upgradeable and unlimited contracts.
 
 ## Step 1: Include dependencies
 
@@ -91,4 +91,4 @@ You can add more basic functionality for your diamond contract by adding functio
 
 When you create a new contract (facet), which you want to make delegate calls from your diamond contract to, you will call the `diamond_cut` function on your diamond contract, with the code hash of your new facet and the selectors of all the functions from this facet you want to use. The diamond will register them and anytime you call this function on your diamond contract, it will make the delegate call to the facet the function belongs to. You can add, remove or replace these functions anytime with the `diamond_cut` function, some of the limitations are, that you can not add functions with the same selectors, when replacing functions, the new function needs to be from a different contract, then currently in use, and when removing functions, the function needs to be registered in the diamond contract.
 
-You can check an example of the usage of [Diamond](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/diamond).
+You can check an example of the usage of [Diamond](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/diamond).

--- a/docs/docs/smart-contracts/example/contract.md
+++ b/docs/docs/smart-contracts/example/contract.md
@@ -16,7 +16,7 @@ implementation of `Lending` and `LendingPermissioned` traits defined in the `len
 ```toml
 [package]
 name = "lending_contract"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
@@ -35,7 +35,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 shares_contract = { path = "../shares", default-features = false, features = ["ink-as-dependency"]  }
 loan_contract = { path = "../loan", default-features = false, features = ["ink-as-dependency"]  }
 lending_project = { path = "../..", default-features = false }
-openbrush = { path = "../../..", default-features = false, features = ["psp22", "psp34", "pausable", "access_control"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["psp22", "psp34", "pausable", "access_control"] }
 
 [lib]
 name = "lending_contract"

--- a/docs/docs/smart-contracts/example/data.md
+++ b/docs/docs/smart-contracts/example/data.md
@@ -142,7 +142,7 @@ In the `Cargo.toml` of the derive folder you need to import `openbrush` dependen
 syn = { version = "1.0" }
 quote = "1.0"
 proc-macro2 = "1"
-openbrush = { version = "~1.8.0", default-features = false }
+openbrush = { version = "~2.0.0", default-features = false }
 
 [lib]
 name = "point_derive"

--- a/docs/docs/smart-contracts/overview.md
+++ b/docs/docs/smart-contracts/overview.md
@@ -23,7 +23,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 # Brush dependency
-openbrush = { version = "~1.8.0", default-features = false }
+openbrush = { version = "~2.0.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/docs/docs/smart-contracts/overview.md
+++ b/docs/docs/smart-contracts/overview.md
@@ -46,8 +46,8 @@ ink-as-dependency = []
 
 To avoid unexpected compilation errors better to always import all ink! crates.
 
-By default, the `openbrush` crate provides [macros](https://github.com/Supercolony-net/openbrush-contracts/blob/main/lang/macro/lib.rs)
-for simplification of the development and [traits](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/traits) of 
+By default, the `openbrush` crate provides [macros](https://github.com/Supercolony-net/openbrush-contracts/blob/main/lang/macro/src/lib.rs)
+for simplification of the development and [traits](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/traits) of 
 contracts(you can implement them by yourself, and you can use them for a cross-contract calls). 
 
 The OpenBrush also provides the default implementation of traits that can be enabled via crate features. 
@@ -64,7 +64,7 @@ You can enable it by adding `#![feature(min_specialization)]` at the top of your
 Also, that doc contains links to the examples of how to reuse and customize the default implementation of traits.
 
 * [PSP22](PSP22/psp22.md) is an example of how you can reuse the implementation of
-  [psp22](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp22). You also can find examples of how to reuse extensions.
+  [psp22](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp22). You also can find examples of how to reuse extensions.
   * [PSP22Metadata](PSP22/Extensions/metadata.md): metadata for PSP22.
   * [PSP22Mintable](PSP22/Extensions/mintable.md): creation of new tokens.
   * [PSP22Burnable](PSP22/Extensions/burnable.md): destruction of own tokens.
@@ -74,30 +74,30 @@ Also, that doc contains links to the examples of how to reuse and customize the 
   * [PSP22Capped](PSP22/Extensions/capped.md): extension which adds a cap for total supply of PSP22 tokens.
   * [PSP22TokenTimelock](PSP22/Utils/token-timelock.md): Utility which allows token holders to lock their tokens for a specified amount of time.
 * [PSP34](PSP34/psp34.md) is an example of how you can reuse the implementation of
-  [psp34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34). You also can find examples of how to reuse extensions.
+  [psp34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34). You also can find examples of how to reuse extensions.
   * [PSP34Metadata](PSP34/Extensions/metadata.md): metadata for PSP34.
   * [PSP34Mintable](PSP34/Extensions/mintable.md): creation of new tokens.
   * [PSP34Burnable](PSP34/Extensions/burnable.md): destruction of own tokens.
 * [PSP1155](PSP1155/psp1155.md) is an example of how you can reuse the implementation of
-  [psp1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155). You also can find examples of how to reuse extensions.
+  [psp1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155). You also can find examples of how to reuse extensions.
   * [PSP1155Metadata](PSP1155/Extensions/metadata.md): metadata for PSP1155.
   * [PSP1155Mintable](PSP1155/Extensions/mintable.md): creation of new tokens.
   * [PSP1155Burnable](PSP1155/Extensions/burnable.md): destruction of own tokens.
 * [Access Control](access-control.md) shows how you can use the implementation of
-  [access-control](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/access/access_control) and
-  [psp34](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp34) together to provide rights to mint and burn NFT tokens.
+  [access-control](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/access/access_control) and
+  [psp34](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp34) together to provide rights to mint and burn NFT tokens.
 * [Ownable](ownable.md) shows how you can use the implementation of
-  [ownable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/access/ownable) and
-  [psp1155](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/token/psp1155) together to provide rights to mint and burn tokens.
+  [ownable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/access/ownable) and
+  [psp1155](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/token/psp1155) together to provide rights to mint and burn tokens.
 * [ReentrancyGuard](reentrancy-guard.md) shows how you can use the implementation of
-  [non_reentrant](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/security/reentrancy_guard)
+  [non_reentrant](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/security/reentrancy_guard)
   modifier to prevent reentrancy during certain functions.
 * [Pausable](pausable.md) shows how you can use the implementation of
-  [pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/security/pausable)
+  [pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/security/pausable)
   contract and modifiers.
 * [TimelockController](timelock-controller.md) shows how you can use the implementation of
-  [timelock-controller](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/governance/timelock_controller)
+  [timelock-controller](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/governance/timelock_controller)
   to execute a transaction with some delay via governance.
 * [PaymentSplitter](payment-splitter.md) shows how you can use the implementation of
-  [payment-splitter](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/finance/payment_splitter)
+  [payment-splitter](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/finance/payment_splitter)
   to split received native tokens between participants of the contract.

--- a/docs/docs/smart-contracts/ownable.md
+++ b/docs/docs/smart-contracts/ownable.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Ownable via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["ownable"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["ownable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/ownable.md
+++ b/docs/docs/smart-contracts/ownable.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 title: Ownable
 ---
 
-This example shows how you can use the implementation of [ownable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/access/ownable) to provide `only owner` rights for contract's functions.
+This example shows how you can use the implementation of [ownable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/access/ownable) to provide `only owner` rights for contract's functions.
 
 ## Step 1: Include dependencies
 
@@ -115,4 +115,4 @@ pub mod my_ownable {
 
 ```
 
-You can check an example of the usage of [Ownable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/ownable).
+You can check an example of the usage of [Ownable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/ownable).

--- a/docs/docs/smart-contracts/pausable.md
+++ b/docs/docs/smart-contracts/pausable.md
@@ -4,7 +4,7 @@ title: Pausable
 ---
 
 This example shows how you can reuse the implementation of
-[pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/security/pausable) in `Flipper` contract to `flip` only if the contract is not paused.
+[pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/security/pausable) in `Flipper` contract to `flip` only if the contract is not paused.
 
 ## Step 1: Include dependencies
 
@@ -117,4 +117,4 @@ pub mod my_pausable {
 }
 ```
 
-You can check an example of the usage of [Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/pausable).
+You can check an example of the usage of [Pausable](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/pausable).

--- a/docs/docs/smart-contracts/pausable.md
+++ b/docs/docs/smart-contracts/pausable.md
@@ -12,7 +12,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Pausable via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["pausable"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["pausable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/payment-splitter.md
+++ b/docs/docs/smart-contracts/payment-splitter.md
@@ -4,7 +4,7 @@ title: Payment Splitter
 ---
 
 This example shows how you can reuse the implementation of
-[payment-splitter](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/finance/payment_splitter).
+[payment-splitter](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/finance/payment_splitter).
 
 ## Step 1: Include dependencies
 
@@ -72,7 +72,7 @@ impl SplitterStruct {
 }
 ```
 
-You can check an example of the usage of [PaymentSplitter](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/payment_splitter).
+You can check an example of the usage of [PaymentSplitter](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/payment_splitter).
 
 ## Step 6 (Optional): Customize your contract
 

--- a/docs/docs/smart-contracts/payment-splitter.md
+++ b/docs/docs/smart-contracts/payment-splitter.md
@@ -12,7 +12,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Payment Splitter via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["payment_splitter"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["payment_splitter"] }
 
 # payment-splitter uses dividing inside, so your version of rust can require you to disable check overflow.
 [profile.dev]

--- a/docs/docs/smart-contracts/proxy.md
+++ b/docs/docs/smart-contracts/proxy.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Proxy via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["proxy"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["proxy"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/proxy.md
+++ b/docs/docs/smart-contracts/proxy.md
@@ -3,7 +3,7 @@ sidebar_position: 3
 title: Proxy
 ---
 
-This example shows how you can use the implementation of [proxy](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/upgradability/proxy) to to implement proxy pattern for upgradeable contracts.
+This example shows how you can use the implementation of [proxy](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/upgradability/proxy) to to implement proxy pattern for upgradeable contracts.
 
 ## Step 1: Include dependencies
 
@@ -102,4 +102,4 @@ impl ProxyContract {
 Generally, proxy doesn't need other functionality, but if you need something you can customize it by adding proxy logic. We will add a `proxy_function` to `ProxyContract` implemenation.
 
 
-You can check an example of the usage of [Proxy](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/proxy).
+You can check an example of the usage of [Proxy](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/proxy).

--- a/docs/docs/smart-contracts/reentrancy-guard.md
+++ b/docs/docs/smart-contracts/reentrancy-guard.md
@@ -20,7 +20,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Reentrancy Guard via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["reentrancy_guard"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["reentrancy_guard"] }
 ```
 
 ### Step 2: Add imports

--- a/docs/docs/smart-contracts/reentrancy-guard.md
+++ b/docs/docs/smart-contracts/reentrancy-guard.md
@@ -3,7 +3,7 @@ sidebar_position: 5
 title: Reentrancy Guard
 ---
 
-This example shows how you can use the [non_reentrant](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/security/reentrancy_guard)
+This example shows how you can use the [non_reentrant](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/security/reentrancy_guard)
 modifier to prevent reentrancy into certain functions. In this example we will create two contracts:
 
 - `my_flipper_guard` - this contract is the simple version of [flipper](https://github.com/paritytech/ink/tree/master/examples/flipper),
@@ -205,7 +205,7 @@ std = [
 ]
 ```
 
-You can check an example of the usage of [ReentrancyGuard](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/reentrancy_guard).
+You can check an example of the usage of [ReentrancyGuard](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/reentrancy_guard).
 
 ## Testing
 

--- a/docs/docs/smart-contracts/timelock-controller.md
+++ b/docs/docs/smart-contracts/timelock-controller.md
@@ -4,7 +4,7 @@ title: Timelock Controller
 ---
 
 This example shows how you can reuse the implementation of
-[timelock-controller](https://github.com/Supercolony-net/openbrush-contracts/tree/master/contracts/src/governance/timelock_controller).
+[timelock-controller](https://github.com/Supercolony-net/openbrush-contracts/tree/main/contracts/src/governance/timelock_controller).
 
 ## Step 1: Include dependencies
 
@@ -75,4 +75,4 @@ impl TimelockStruct {
 }
 ```
 
-You can check an example of the usage of [TimelockController](https://github.com/Supercolony-net/openbrush-contracts/tree/master/examples/timelock_controller).
+You can check an example of the usage of [TimelockController](https://github.com/Supercolony-net/openbrush-contracts/tree/main/examples/timelock_controller).

--- a/docs/docs/smart-contracts/timelock-controller.md
+++ b/docs/docs/smart-contracts/timelock-controller.md
@@ -12,7 +12,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Timelock Controller via `openbrush` features.
 
 ```toml
-openbrush = { version = "~1.8.0", default-features = false, features = ["timelock_controller"] }
+openbrush = { version = "~2.0.0", default-features = false, features = ["timelock_controller"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbrush",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/example_project_structure/Cargo.toml
+++ b/example_project_structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net, dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/lending/Cargo.toml
+++ b/example_project_structure/contracts/lending/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_contract"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/loan/Cargo.toml
+++ b/example_project_structure/contracts/loan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loan_contract"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/shares/Cargo.toml
+++ b/example_project_structure/contracts/shares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shares_contract"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/stable_coin/Cargo.toml
+++ b/example_project_structure/contracts/stable_coin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable_coin_contract"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/derive/Cargo.toml
+++ b/example_project_structure/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project_derive"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
@@ -10,7 +10,7 @@ quote = "1.0"
 proc-macro2 = "1"
 
 # In you code you can import `openbrush_derive` with the next line
-#openbrush = { version = "~1.8.0", default-features = false }
+#openbrush = { version = "~2.0.0", default-features = false }
 
 openbrush = { package = "openbrush_lang", path = "../../lang" }
 

--- a/examples/access_control/Cargo.toml
+++ b/examples/access_control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_access_control"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/Cargo.toml
+++ b/examples/diamond/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_diamond"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/diamond_caller/Cargo.toml
+++ b/examples/diamond/diamond_caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diamond_caller"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_facet_v1/Cargo.toml
+++ b/examples/diamond/psp22_facet_v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_facet_v1"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_facet_v2/Cargo.toml
+++ b/examples/diamond/psp22_facet_v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_facet_v2"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_metadata_facet/Cargo.toml
+++ b/examples/diamond/psp22_metadata_facet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata_facet"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_ownable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_pausable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/payment_splitter/Cargo.toml
+++ b/examples/payment_splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_payment_splitter"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_proxy"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata_upgradeable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/psp22_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_upgradeable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155/Cargo.toml
+++ b/examples/psp1155/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155_extensions/burnable/Cargo.toml
+++ b/examples/psp1155_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_burnable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155_extensions/metadata/Cargo.toml
+++ b/examples/psp1155_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_metadata"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp1155_extensions/mintable/Cargo.toml
+++ b/examples/psp1155_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp1155_mintable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22/Cargo.toml
+++ b/examples/psp22/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/burnable/Cargo.toml
+++ b/examples/psp22_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_burnable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/capped/Cargo.toml
+++ b/examples/psp22_extensions/capped/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_capped"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/flashmint/Cargo.toml
+++ b/examples/psp22_extensions/flashmint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_flashmint"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/metadata/Cargo.toml
+++ b/examples/psp22_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/mintable/Cargo.toml
+++ b/examples/psp22_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_mintable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/pausable/Cargo.toml
+++ b/examples/psp22_extensions/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pausable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/wrapper/Cargo.toml
+++ b/examples/psp22_extensions/wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_wrapper"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_utils/token_timelock/Cargo.toml
+++ b/examples/psp22_utils/token_timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_token_timelock"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34/Cargo.toml
+++ b/examples/psp34/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/burnable/Cargo.toml
+++ b/examples/psp34_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_burnable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/enumerable/Cargo.toml
+++ b/examples/psp34_extensions/enumerable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_enumerable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/metadata/Cargo.toml
+++ b/examples/psp34_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_metadata"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/mintable/Cargo.toml
+++ b/examples/psp34_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_mintable"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/Cargo.toml
+++ b/examples/reentrancy_guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flip_on_me"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/contracts/flipper/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_flipper_guard"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/timelock_controller/Cargo.toml
+++ b/examples/timelock_controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_timelock_controller"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -14,7 +14,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-openbrush_lang_macro = { version = "~1.8.0", path = "macro", default-features = false }
+openbrush_lang_macro = { version = "~2.0.0", path = "macro", default-features = false }
 
 ink_env = { version = "~3.2.0", default-features = false }
 ink_lang = { version = "~3.2.0", default-features = false }

--- a/lang/codegen/Cargo.toml
+++ b/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang_codegen"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/lang/macro/Cargo.toml
+++ b/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang_macro"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -14,7 +14,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-openbrush_lang_codegen = { version = "~1.8.0", path = "../codegen", default-features = false }
+openbrush_lang_codegen = { version = "~2.0.0", path = "../codegen", default-features = false }
 syn = "1"
 proc-macro2 = "1"
 synstructure = "0.12"

--- a/mock/flash-borrower/Cargo.toml
+++ b/mock/flash-borrower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash_borrower"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp1155-receiver/Cargo.toml
+++ b/mock/psp1155-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp1155_receiver"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp22-receiver/Cargo.toml
+++ b/mock/psp22-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_receiver"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp34-receiver/Cargo.toml
+++ b/mock/psp34-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp34_receiver"
-version = "1.8.0"
+version = "2.0.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,11 +1,11 @@
-cargo publish --package openbrush_lang_codegen --keep-going
+cargo publish --manifest-path lang/codegen/Cargo.toml --keep-going
 sleep 5
-cargo publish --package openbrush_lang_macro --keep-going
+cargo publish --manifest-path lang/macro/Cargo.toml --keep-going
 sleep 5
-cargo publish --package openbrush_lang --keep-going
+cargo publish --manifest-path lang/Cargo.toml --keep-going
 sleep 5
-cargo publish --package openbrush_contracts_derive --keep-going
+cargo publish --manifest-path contracts/derive/Cargo.toml --keep-going
 sleep 5
-cargo publish --package openbrush_contracts --keep-going
+cargo publish --manifest-path contracts/Cargo.toml --keep-going
 sleep 5
-cargo publish --package openbrush --keep-going
+cargo publish --manifest-path Cargo.toml --keep-going


### PR DESCRIPTION
Instead of [releasing 1.8.0](https://github.com/Supercolony-net/openbrush-contracts/pull/123) better to create a major 2.0.0 because we renamed the crate `brush` -> `openbrush`. 