### PR TITLE
`MultipleValueMapping` and strict `Mapping`

### DIFF
--- a/contracts/src/access/ownable/mod.rs
+++ b/contracts/src/access/ownable/mod.rs
@@ -41,13 +41,13 @@ pub struct OwnableData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(OwnableStorage, OwnableData);
+declare_storage_trait!(OwnableStorage);
 
 /// Throws if called by any account other than the owner.
 #[modifier_definition]
 pub fn only_owner<T, F, R, E>(instance: &mut T, body: F) -> Result<R, E>
 where
-    T: OwnableStorage,
+    T: OwnableStorage<Data = OwnableData>,
     F: FnOnce(&mut T) -> Result<R, E>,
     E: From<OwnableError>,
 {
@@ -57,7 +57,7 @@ where
     body(instance)
 }
 
-impl<T: OwnableStorage> Ownable for T {
+impl<T: OwnableStorage<Data = OwnableData>> Ownable for T {
     default fn owner(&self) -> AccountId {
         self.get().owner.clone()
     }
@@ -89,7 +89,7 @@ pub trait OwnableInternal {
     fn _init_with_owner(&mut self, owner: AccountId);
 }
 
-impl<T: OwnableStorage> OwnableInternal for T {
+impl<T: OwnableStorage<Data = OwnableData>> OwnableInternal for T {
     /// User must override this method in their contract.
     default fn _emit_ownership_transferred_event(
         &self,

--- a/contracts/src/finance/payment_splitter/mod.rs
+++ b/contracts/src/finance/payment_splitter/mod.rs
@@ -46,9 +46,9 @@ pub struct PaymentSplitterData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PaymentSplitterStorage, PaymentSplitterData);
+declare_storage_trait!(PaymentSplitterStorage);
 
-impl<T: PaymentSplitterStorage> PaymentSplitter for T {
+impl<T: PaymentSplitterStorage<Data = PaymentSplitterData>> PaymentSplitter for T {
     default fn total_shares(&self) -> Balance {
         self.get().total_shares.clone()
     }
@@ -131,7 +131,7 @@ pub trait PaymentSplitterInternal {
     fn _release_all(&mut self) -> Result<(), PaymentSplitterError>;
 }
 
-impl<T: PaymentSplitterStorage> PaymentSplitterInternal for T {
+impl<T: PaymentSplitterStorage<Data = PaymentSplitterData>> PaymentSplitterInternal for T {
     default fn _emit_payee_added_event(&self, _account: AccountId, _shares: Balance) {}
 
     default fn _emit_payment_received_event(&self, _from: AccountId, _amount: Balance) {}

--- a/contracts/src/governance/timelock_controller/mod.rs
+++ b/contracts/src/governance/timelock_controller/mod.rs
@@ -65,14 +65,16 @@ pub struct TimelockControllerData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(TimelockControllerStorage, TimelockControllerData);
+declare_storage_trait!(TimelockControllerStorage);
 
-impl<T: TimelockControllerStorage> AccessControlStorage for T {
-    fn get(&self) -> &AccessControlData {
+impl<T: TimelockControllerStorage<Data = TimelockControllerData>> AccessControlStorage for T {
+    type Data = AccessControlData;
+
+    fn get(&self) -> &Self::Data {
         &T::get(self).access_control
     }
 
-    fn get_mut(&mut self) -> &mut AccessControlData {
+    fn get_mut(&mut self) -> &mut Self::Data {
         &mut T::get_mut(self).access_control
     }
 }
@@ -84,7 +86,7 @@ impl<T: TimelockControllerStorage> AccessControlStorage for T {
 #[modifier_definition]
 pub fn only_role_or_open_role<T, F, R, E>(instance: &mut T, body: F, role: RoleType) -> Result<R, E>
 where
-    T: AccessControlStorage,
+    T: AccessControlStorage<Data = AccessControlData>,
     F: FnOnce(&mut T) -> Result<R, E>,
     E: From<AccessControlError>,
 {
@@ -100,7 +102,7 @@ pub const EXECUTOR_ROLE: RoleType = ink_lang::selector_id!("EXECUTOR_ROLE");
 
 pub const DONE_TIMESTAMP: Timestamp = 1;
 
-impl<T: TimelockControllerStorage + Flush> TimelockController for T {
+impl<T: TimelockControllerStorage<Data = TimelockControllerData> + Flush> TimelockController for T {
     default fn is_operation(&self, id: OperationId) -> bool {
         self.get_timestamp(id) > Timestamp::default()
     }
@@ -303,7 +305,7 @@ pub trait TimelockControllerInternal {
     fn _done_timestamp() -> Timestamp;
 }
 
-impl<T: TimelockControllerStorage + Flush> TimelockControllerInternal for T {
+impl<T: TimelockControllerStorage<Data = TimelockControllerData> + Flush> TimelockControllerInternal for T {
     default fn _emit_min_delay_change_event(&self, _old_delay: Timestamp, _new_delay: Timestamp) {}
 
     default fn _emit_call_scheduled_event(

--- a/contracts/src/security/pausable/mod.rs
+++ b/contracts/src/security/pausable/mod.rs
@@ -37,13 +37,13 @@ pub struct PausableData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PausableStorage, PausableData);
+declare_storage_trait!(PausableStorage);
 
 /// Modifier to make a function callable only when the contract is paused.
 #[modifier_definition]
 pub fn when_paused<T, F, R, E>(instance: &mut T, body: F) -> Result<R, E>
 where
-    T: PausableStorage,
+    T: PausableStorage<Data = PausableData>,
     F: FnOnce(&mut T) -> Result<R, E>,
     E: From<PausableError>,
 {
@@ -57,7 +57,7 @@ where
 #[modifier_definition]
 pub fn when_not_paused<T, F, R, E>(instance: &mut T, body: F) -> Result<R, E>
 where
-    T: PausableStorage,
+    T: PausableStorage<Data = PausableData>,
     F: FnOnce(&mut T) -> Result<R, E>,
     E: From<PausableError>,
 {
@@ -67,7 +67,7 @@ where
     body(instance)
 }
 
-impl<T: PausableStorage> Pausable for T {
+impl<T: PausableStorage<Data = PausableData>> Pausable for T {
     default fn paused(&self) -> bool {
         self.get().paused
     }
@@ -93,7 +93,7 @@ pub trait PausableInternal {
     fn _unpause<E: From<PausableError>>(&mut self) -> Result<(), E>;
 }
 
-impl<T: PausableStorage> PausableInternal for T {
+impl<T: PausableStorage<Data = PausableData>> PausableInternal for T {
     default fn _emit_paused_event(&self, _account: AccountId) {}
 
     default fn _emit_unpaused_event(&self, _account: AccountId) {}

--- a/contracts/src/security/reentrancy_guard/mod.rs
+++ b/contracts/src/security/reentrancy_guard/mod.rs
@@ -36,7 +36,7 @@ pub struct ReentrancyGuardData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(ReentrancyGuardStorage, ReentrancyGuardData);
+declare_storage_trait!(ReentrancyGuardStorage);
 
 const NOT_ENTERED: u8 = 0;
 const ENTERED: u8 = 1;
@@ -52,7 +52,7 @@ const ENTERED: u8 = 1;
 #[modifier_definition]
 pub fn non_reentrant<T, F, R, E>(instance: &mut T, body: F) -> Result<R, E>
 where
-    T: ReentrancyGuardStorage,
+    T: ReentrancyGuardStorage<Data = ReentrancyGuardData>,
     F: FnOnce(&mut T) -> Result<R, E>,
     E: From<ReentrancyGuardError>,
 {

--- a/contracts/src/token/psp22/extensions/metadata.rs
+++ b/contracts/src/token/psp22/extensions/metadata.rs
@@ -38,9 +38,9 @@ pub struct PSP22MetadataData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PSP22MetadataStorage, PSP22MetadataData);
+declare_storage_trait!(PSP22MetadataStorage);
 
-impl<T: PSP22MetadataStorage> PSP22Metadata for T {
+impl<T: PSP22MetadataStorage<Data = PSP22MetadataData>> PSP22Metadata for T {
     default fn token_name(&self) -> Option<String> {
         self.get().name.clone()
     }

--- a/contracts/src/token/psp22/extensions/wrapper.rs
+++ b/contracts/src/token/psp22/extensions/wrapper.rs
@@ -43,9 +43,9 @@ pub struct PSP22WrapperData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PSP22WrapperStorage, PSP22WrapperData);
+declare_storage_trait!(PSP22WrapperStorage);
 
-impl<T: PSP22 + PSP22WrapperStorage + PSP22Internal> PSP22Wrapper for T {
+impl<T: PSP22 + PSP22WrapperStorage<Data = PSP22WrapperData> + PSP22Internal> PSP22Wrapper for T {
     default fn deposit_for(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error> {
         self._deposit(amount)?;
         self._mint(account, amount)
@@ -80,7 +80,7 @@ pub trait PSP22WrapperInternal {
     fn _underlying(&mut self) -> &mut PSP22Ref;
 }
 
-impl<T: PSP22 + PSP22Internal + PSP22WrapperStorage> PSP22WrapperInternal for T {
+impl<T: PSP22 + PSP22Internal + PSP22WrapperStorage<Data = PSP22WrapperData>> PSP22WrapperInternal for T {
     default fn _recover(&mut self, account: AccountId) -> Result<Balance, PSP22Error> {
         let value = self._underlying_balance() - self.total_supply();
         self._mint(account, value)?;

--- a/contracts/src/token/psp22/psp22.rs
+++ b/contracts/src/token/psp22/psp22.rs
@@ -60,9 +60,9 @@ pub struct PSP22Data {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PSP22Storage, PSP22Data);
+declare_storage_trait!(PSP22Storage);
 
-impl<T: PSP22Storage + Flush> PSP22 for T {
+impl<T: PSP22Storage<Data = PSP22Data> + Flush> PSP22 for T {
     default fn total_supply(&self) -> Balance {
         self.get().supply.clone()
     }
@@ -155,7 +155,7 @@ pub trait PSP22Internal {
     fn _burn_from(&mut self, account: AccountId, amount: Balance) -> Result<(), PSP22Error>;
 }
 
-impl<T: PSP22Storage + Flush> PSP22Internal for T {
+impl<T: PSP22Storage<Data = PSP22Data> + Flush> PSP22Internal for T {
     default fn _emit_transfer_event(&self, _from: Option<AccountId>, _to: Option<AccountId>, _amount: Balance) {}
 
     default fn _emit_approval_event(&self, _owner: AccountId, _spender: AccountId, _amount: Balance) {}

--- a/contracts/src/token/psp22/utils/token_timelock.rs
+++ b/contracts/src/token/psp22/utils/token_timelock.rs
@@ -45,9 +45,9 @@ pub struct PSP22TokenTimelockData {
     release_time: Timestamp,
 }
 
-declare_storage_trait!(PSP22TokenTimelockStorage, PSP22TokenTimelockData);
+declare_storage_trait!(PSP22TokenTimelockStorage);
 
-impl<T: PSP22TokenTimelockStorage> PSP22TokenTimelock for T {
+impl<T: PSP22TokenTimelockStorage<Data = PSP22TokenTimelockData>> PSP22TokenTimelock for T {
     /// Returns the token address
     default fn token(&self) -> AccountId {
         self.get().token
@@ -95,7 +95,7 @@ pub trait PSP22TokenTimelockInternal {
     fn _token(&mut self) -> &mut PSP22Ref;
 }
 
-impl<T: PSP22TokenTimelockStorage> PSP22TokenTimelockInternal for T {
+impl<T: PSP22TokenTimelockStorage<Data = PSP22TokenTimelockData>> PSP22TokenTimelockInternal for T {
     default fn _withdraw(&mut self, amount: Balance) -> Result<(), PSP22TokenTimelockError> {
         let beneficairy = self.beneficiary();
         self._token()

--- a/contracts/src/token/psp34/balances.rs
+++ b/contracts/src/token/psp34/balances.rs
@@ -1,3 +1,24 @@
+// Copyright (c) 2012-2022 Supercolony
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the"Software"),
+// to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 use crate::psp34::{
     Id,
     Owner,

--- a/contracts/src/token/psp34/balances.rs
+++ b/contracts/src/token/psp34/balances.rs
@@ -1,0 +1,56 @@
+use crate::psp34::{
+    Id,
+    Owner,
+};
+use openbrush::{
+    storage::Mapping,
+    traits::Balance,
+};
+
+pub const BALANCES_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP34Balances");
+
+pub trait BalancesManager {
+    fn balance_of(&self, owner: &Owner) -> u32;
+    fn increase_balance(&mut self, owner: &Owner, id: &Id, increase_supply: bool);
+    fn decrease_balance(&mut self, owner: &Owner, id: &Id, decrease_supply: bool);
+    fn total_supply(&self) -> Balance;
+}
+
+#[derive(Default, Debug)]
+#[openbrush::storage(BALANCES_KEY)]
+pub struct Balances {
+    owned_tokens_count: Mapping<Owner, u32>,
+    total_supply: Balance,
+}
+
+impl BalancesManager for Balances {
+    #[inline(always)]
+    fn balance_of(&self, owner: &Owner) -> u32 {
+        self.owned_tokens_count.get(owner).unwrap_or(0)
+    }
+
+    #[inline(always)]
+    fn increase_balance(&mut self, owner: &Owner, _id: &Id, increase_supply: bool) {
+        let to_balance = self.owned_tokens_count.get(owner).unwrap_or(0);
+        self.owned_tokens_count.insert(owner, &(to_balance + 1));
+        if increase_supply {
+            self.total_supply += 1;
+        }
+    }
+
+    #[inline(always)]
+    fn decrease_balance(&mut self, owner: &Owner, _id: &Id, decrease_supply: bool) {
+        let from_balance = self.owned_tokens_count.get(owner).unwrap_or(0);
+        self.owned_tokens_count
+            .insert(owner, &(from_balance.checked_sub(1).unwrap()));
+
+        if decrease_supply {
+            self.total_supply -= 1;
+        }
+    }
+
+    #[inline(always)]
+    fn total_supply(&self) -> u128 {
+        self.total_supply
+    }
+}

--- a/contracts/src/token/psp34/extensions/enumerable.rs
+++ b/contracts/src/token/psp34/extensions/enumerable.rs
@@ -24,10 +24,12 @@ pub use crate::{
     traits::psp34::extensions::enumerable::*,
 };
 pub use derive::PSP34EnumerableStorage;
-use ink_storage::Mapping;
-use openbrush::traits::{
-    AccountId,
-    Flush,
+use openbrush::{
+    storage::MultipleValueMapping,
+    traits::{
+        AccountId,
+        Flush,
+    },
 };
 
 pub const STORAGE_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP34EnumerableData");
@@ -35,7 +37,7 @@ pub const STORAGE_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP34Enumera
 #[derive(Default, Debug)]
 #[openbrush::storage(STORAGE_KEY)]
 pub struct PSP34EnumerableData {
-    pub enumerable: EnumerableMapping,
+    pub enumerable: MultipleValueMapping<Option<AccountId>, Id>,
     pub _reserved: Option<()>,
 }
 
@@ -79,6 +81,10 @@ pub trait PSP34EnumerableInternal {
         to: Option<&AccountId>,
         id: &Id,
     ) -> Result<(), PSP34Error>;
+
+    fn _enumerable(&self) -> &PSP34EnumerableData;
+
+    fn _enumerable_mut(&mut self) -> &mut PSP34EnumerableData;
 }
 
 impl<T: PSP34EnumerableStorage + Flush> PSP34EnumerableInternal for T {
@@ -93,85 +99,51 @@ impl<T: PSP34EnumerableStorage + Flush> PSP34EnumerableInternal for T {
         }
 
         if from.is_none() {
-            let last_free_index = self._total_supply();
-            PSP34EnumerableStorage::get_mut(self)
+            self._enumerable_mut()
                 .enumerable
-                .insert(&None, id, &last_free_index);
+                .insert::<Option<&AccountId>, Id>(&None, id);
         } else {
-            let from = from.unwrap();
-            let last_index = (self._balance_of(from) - 1) as u128;
-            PSP34EnumerableStorage::get_mut(self)
+            self._enumerable_mut()
                 .enumerable
-                .remove(&Some(from.clone()), id, &last_index)?;
+                .remove_value::<Option<&AccountId>, Id>(&from, id);
         }
 
         if to.is_none() {
-            let last_index = self._total_supply() - 1;
-            PSP34EnumerableStorage::get_mut(self)
+            self._enumerable_mut()
                 .enumerable
-                .remove(&None, id, &last_index)?;
+                .remove_value::<Option<&AccountId>, Id>(&None, id);
         } else {
-            let to = to.unwrap();
-            let last_free_index = (self._balance_of(to)) as u128;
-            PSP34EnumerableStorage::get_mut(self)
+            self._enumerable_mut()
                 .enumerable
-                .insert(&Some(to.clone()), id, &last_free_index);
+                .insert::<Option<&AccountId>, Id>(&to, id);
         }
 
         Ok(())
+    }
+
+    #[inline(always)]
+    fn _enumerable(&self) -> &PSP34EnumerableData {
+        PSP34EnumerableStorage::get(self)
+    }
+
+    #[inline(always)]
+    fn _enumerable_mut(&mut self) -> &mut PSP34EnumerableData {
+        PSP34EnumerableStorage::get_mut(self)
     }
 }
 
 impl<T: PSP34EnumerableStorage + Flush> PSP34Enumerable for T {
     default fn owners_token_by_index(&self, owner: AccountId, index: u128) -> Result<Id, PSP34Error> {
-        PSP34EnumerableStorage::get(self)
+        self._enumerable()
             .enumerable
-            .get_by_index(&Some(owner), &index)
+            .get_value::<Option<&AccountId>>(&Some(&owner), &index)
+            .ok_or(PSP34Error::TokenNotExists)
     }
 
     default fn token_by_index(&self, index: u128) -> Result<Id, PSP34Error> {
-        PSP34EnumerableStorage::get(self).enumerable.get_by_index(&None, &index)
-    }
-}
-
-#[derive(Default, Debug, ink_storage::traits::SpreadLayout, ink_storage::traits::SpreadAllocate)]
-#[cfg_attr(feature = "std", derive(ink_storage::traits::StorageLayout))]
-pub struct EnumerableMapping {
-    /// Mapping from index to `Id`.
-    ///
-    /// ** Note ** Owner can be `None` to track existence of the token in the contract
-    id_to_index: Mapping<(Option<AccountId>, Id), u128>,
-    /// Mapping from owner's index to `Id`.
-    ///
-    /// ** Note ** Owner can be `None` that means it is a contract.
-    index_to_id: Mapping<(Option<AccountId>, u128), Id>,
-}
-
-impl EnumerableMapping {
-    pub fn insert(&mut self, owner: &Option<AccountId>, id: &Id, index: &u128) {
-        self.id_to_index.insert((owner, id), index);
-        self.index_to_id.insert((owner, index), id);
-    }
-
-    pub fn remove(&mut self, owner: &Option<AccountId>, id: &Id, last_index: &u128) -> Result<(), PSP34Error> {
-        let index = self.id_to_index.get((owner, id)).ok_or(PSP34Error::TokenNotExists)?;
-
-        if last_index != &index {
-            let last_id = self
-                .index_to_id
-                .get((owner, last_index))
-                .ok_or(PSP34Error::TokenNotExists)?;
-            self.index_to_id.insert((owner, &index), &last_id);
-            self.id_to_index.insert((owner, &last_id), &index);
-        }
-
-        self.index_to_id.remove((owner, &last_index));
-        self.id_to_index.remove((owner, id));
-
-        Ok(())
-    }
-
-    pub fn get_by_index(&self, owner: &Option<AccountId>, index: &u128) -> Result<Id, PSP34Error> {
-        self.index_to_id.get((owner, index)).ok_or(PSP34Error::TokenNotExists)
+        self._enumerable()
+            .enumerable
+            .get_value::<Option<&AccountId>>(&None, &index)
+            .ok_or(PSP34Error::TokenNotExists)
     }
 }

--- a/contracts/src/token/psp34/extensions/enumerable.rs
+++ b/contracts/src/token/psp34/extensions/enumerable.rs
@@ -19,19 +19,21 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+use crate::psp34::BalancesManager;
 pub use crate::{
     psp34::*,
     traits::psp34::extensions::enumerable::*,
 };
 pub use derive::PSP34EnumerableStorage;
 use openbrush::{
+    declare_storage_trait,
     storage::{
         MultiMapping,
         TypeGuard,
     },
     traits::{
         AccountId,
-        Flush,
+        Balance,
     },
 };
 
@@ -39,8 +41,8 @@ pub const STORAGE_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP34Enumera
 
 #[derive(Default, Debug)]
 #[openbrush::storage(STORAGE_KEY)]
-pub struct PSP34EnumerableData {
-    pub enumerable: MultiMapping<Option<AccountId>, Id, EnumerableKey /* for optimization */>,
+pub struct EnumerableBalances {
+    pub enumerable: MultiMapping<Option<AccountId>, Id, EnumerableKey /* optimization */>,
     pub _reserved: Option<()>,
 }
 
@@ -50,99 +52,57 @@ impl<'a> TypeGuard<'a> for EnumerableKey {
     type Type = &'a Option<&'a AccountId>;
 }
 
-pub trait PSP34EnumerableStorage: PSP34Storage + ::openbrush::traits::InkStorage {
-    fn get(&self) -> &PSP34EnumerableData;
-    fn get_mut(&mut self) -> &mut PSP34EnumerableData;
-}
+declare_storage_trait!(PSP34EnumerableBalancesStorage);
 
-impl<T: PSP34EnumerableStorage + Flush> PSP34Transfer for T {
-    default fn _before_token_transfer(
-        &mut self,
-        from: Option<&AccountId>,
-        to: Option<&AccountId>,
-        id: &Id,
-    ) -> Result<(), PSP34Error> {
-        self._track_id_transfer(from, to, id)
+impl BalancesManager for EnumerableBalances {
+    fn balance_of(&self, owner: &Owner) -> u32 {
+        self.enumerable.count(&Some(owner)) as u32
     }
 
-    default fn _after_token_transfer(
-        &mut self,
-        _from: Option<&AccountId>,
-        _to: Option<&AccountId>,
-        _id: &Id,
-    ) -> Result<(), PSP34Error> {
-        Ok(())
-    }
-}
-
-pub trait PSP34EnumerableInternal {
-    /// Help function that can be called in `_before_token_transfer`. The function tracks moving of
-    /// the token between account to update enumerable data.
-    /// Calling conditions:
-    ///
-    /// - When `from` and `to` are both `None`, ``from``'s `id` will be
-    /// transferred to `to`.
-    /// - When `from` is `None`, `id` will be minted for `to`.
-    /// - When `to` is `None`, ``from``'s `id` will be burned.
-    fn _track_id_transfer(
-        &mut self,
-        from: Option<&AccountId>,
-        to: Option<&AccountId>,
-        id: &Id,
-    ) -> Result<(), PSP34Error>;
-
-    fn _enumerable(&self) -> &PSP34EnumerableData;
-
-    fn _enumerable_mut(&mut self) -> &mut PSP34EnumerableData;
-}
-
-impl<T: PSP34EnumerableStorage + Flush> PSP34EnumerableInternal for T {
-    default fn _track_id_transfer(
-        &mut self,
-        from: Option<&AccountId>,
-        to: Option<&AccountId>,
-        id: &Id,
-    ) -> Result<(), PSP34Error> {
-        if from == to {
-            return Ok(())
+    fn increase_balance(&mut self, owner: &Owner, id: &Id, increase_supply: bool) {
+        self.enumerable.insert(&Some(owner), id);
+        if increase_supply {
+            self.enumerable.insert(&None, id);
         }
-
-        if from.is_none() {
-            self._enumerable_mut().enumerable.insert(&None, id);
-        } else {
-            self._enumerable_mut().enumerable.remove_value(&from, id);
-        }
-
-        if to.is_none() {
-            self._enumerable_mut().enumerable.remove_value(&None, id);
-        } else {
-            self._enumerable_mut().enumerable.insert(&to, id);
-        }
-
-        Ok(())
     }
 
-    #[inline(always)]
-    fn _enumerable(&self) -> &PSP34EnumerableData {
-        PSP34EnumerableStorage::get(self)
+    fn decrease_balance(&mut self, owner: &Owner, id: &Id, decrease_supply: bool) {
+        self.enumerable.remove_value(&Some(owner), id);
+        if decrease_supply {
+            self.enumerable.remove_value(&None, id);
+        }
     }
 
-    #[inline(always)]
-    fn _enumerable_mut(&mut self) -> &mut PSP34EnumerableData {
-        PSP34EnumerableStorage::get_mut(self)
+    fn total_supply(&self) -> Balance {
+        self.enumerable.count(&None)
     }
 }
 
-impl<T: PSP34EnumerableStorage + Flush> PSP34Enumerable for T {
+impl<T> PSP34EnumerableBalancesStorage for T
+where
+    T: PSP34Storage<Data = PSP34Data<EnumerableBalances>>,
+{
+    type Data = EnumerableBalances;
+
+    fn get(&self) -> &Self::Data {
+        &self.get().balances
+    }
+
+    fn get_mut(&mut self) -> &mut Self::Data {
+        &mut self.get_mut().balances
+    }
+}
+
+impl<T: PSP34EnumerableBalancesStorage<Data = EnumerableBalances> + PSP34> PSP34Enumerable for T {
     default fn owners_token_by_index(&self, owner: AccountId, index: u128) -> Result<Id, PSP34Error> {
-        self._enumerable()
+        self.get()
             .enumerable
             .get_value(&Some(&owner), &index)
             .ok_or(PSP34Error::TokenNotExists)
     }
 
     default fn token_by_index(&self, index: u128) -> Result<Id, PSP34Error> {
-        self._enumerable()
+        self.get()
             .enumerable
             .get_value(&None, &index)
             .ok_or(PSP34Error::TokenNotExists)

--- a/contracts/src/token/psp34/extensions/metadata.rs
+++ b/contracts/src/token/psp34/extensions/metadata.rs
@@ -40,9 +40,9 @@ pub struct PSP34MetadataData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PSP34MetadataStorage, PSP34MetadataData);
+declare_storage_trait!(PSP34MetadataStorage);
 
-impl<T: PSP34MetadataStorage> PSP34Metadata for T {
+impl<T: PSP34MetadataStorage<Data = PSP34MetadataData>> PSP34Metadata for T {
     default fn get_attribute(&self, id: Id, key: Vec<u8>) -> Option<Vec<u8>> {
         self.get().attributes.get((&id, &key))
     }
@@ -52,7 +52,7 @@ pub trait PSP34MetadataInternal {
     fn _set_attribute(&mut self, id: Id, key: Vec<u8>, value: Vec<u8>);
 }
 
-impl<T: PSP34MetadataStorage + PSP34Internal> PSP34MetadataInternal for T {
+impl<T: PSP34MetadataStorage<Data = PSP34MetadataData> + PSP34Internal> PSP34MetadataInternal for T {
     default fn _set_attribute(&mut self, id: Id, key: Vec<u8>, value: Vec<u8>) {
         self.get_mut().attributes.insert((&id, &key), &value);
         self._emit_attribute_set_event(id, key, value);

--- a/contracts/src/token/psp34/mod.rs
+++ b/contracts/src/token/psp34/mod.rs
@@ -19,6 +19,9 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+use openbrush::traits::AccountId;
+
+mod balances;
 pub mod psp34;
 
 pub use psp34::*;
@@ -28,3 +31,6 @@ pub mod extensions {
     pub mod metadata;
     pub mod mintable;
 }
+
+pub type Owner = AccountId;
+pub type Operator = AccountId;

--- a/contracts/src/token/psp34/psp34.rs
+++ b/contracts/src/token/psp34/psp34.rs
@@ -147,12 +147,11 @@ impl<T: PSP34Storage + Flush> PSP34Internal for T {
         let mut caller = Self::env().caller();
 
         if id.is_some() {
-            let maybe_owner = self.get().token_owner.get(id.as_ref().unwrap());
-
-            if maybe_owner.is_none() {
-                return Err(PSP34Error::TokenNotExists)
-            }
-            let owner = maybe_owner.unwrap();
+            let owner = self
+                .get()
+                .token_owner
+                .get(id.as_ref().unwrap())
+                .ok_or(PSP34Error::TokenNotExists)?;
 
             if approved && owner == to {
                 return Err(PSP34Error::SelfApprove)

--- a/contracts/src/token/psp35/extensions/batch.rs
+++ b/contracts/src/token/psp35/extensions/batch.rs
@@ -78,7 +78,7 @@ impl<T: PSP35Internal + InkStorage> PSP35BatchInternal for T {
                 return Err(PSP35Error::TransferToZeroAddress)
             }
 
-            if from != operator && &self._get_allowance(&from, &operator, &Some(id.clone())) < value {
+            if from != operator && &self._get_allowance(&from, &operator, &Some(id)) < value {
                 return Err(PSP35Error::NotAllowed)
             }
         }
@@ -86,7 +86,7 @@ impl<T: PSP35Internal + InkStorage> PSP35BatchInternal for T {
         self._before_token_transfer(Some(&from), Some(&to), &ids_amounts)?;
 
         for (id, value) in &ids_amounts {
-            self._decrease_allowance(&from, &operator, id.clone(), value.clone())?;
+            self._decrease_allowance(&from, &operator, id, value.clone())?;
 
             self._decrease_sender_balance(&from, &id, value.clone())?;
         }

--- a/contracts/src/token/psp35/extensions/metadata.rs
+++ b/contracts/src/token/psp35/extensions/metadata.rs
@@ -37,9 +37,9 @@ pub struct PSP35MetadataData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(PSP35MetadataStorage, PSP35MetadataData);
+declare_storage_trait!(PSP35MetadataStorage);
 
-impl<T: PSP35MetadataStorage> PSP35Metadata for T {
+impl<T: PSP35MetadataStorage<Data = PSP35MetadataData>> PSP35Metadata for T {
     default fn get_attribute(&self, id: Id, key: Vec<u8>) -> Option<Vec<u8>> {
         self.get().attributes.get(&(id, key))
     }
@@ -53,7 +53,7 @@ pub trait PSP35MetadataInternal {
     fn _emit_attribute_set_event(&self, _id: &Id, _key: &Vec<u8>, _data: &Vec<u8>);
 }
 
-impl<T: PSP35MetadataStorage> PSP35MetadataInternal for T {
+impl<T: PSP35MetadataStorage<Data = PSP35MetadataData>> PSP35MetadataInternal for T {
     default fn _set_attribute(&mut self, id: &Id, key: &Vec<u8>, data: &Vec<u8>) -> Result<(), PSP35Error> {
         self.get_mut().attributes.insert((id, key), data);
         self._emit_attribute_set_event(id, key, data);

--- a/contracts/src/token/psp35/psp35.rs
+++ b/contracts/src/token/psp35/psp35.rs
@@ -31,9 +31,12 @@ use ink_prelude::{
     vec,
     vec::Vec,
 };
-use ink_storage::Mapping;
 use openbrush::{
     declare_storage_trait,
+    storage::{
+        Mapping,
+        TypeGuard,
+    },
     traits::{
         AccountId,
         AccountIdExt,
@@ -47,9 +50,22 @@ pub const STORAGE_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP35Data");
 #[derive(Default, Debug)]
 #[openbrush::storage(STORAGE_KEY)]
 pub struct PSP35Data {
-    pub balances: Mapping<(Id, AccountId), Balance>,
-    pub operator_approvals: Mapping<(AccountId, AccountId, Option<Id>), Balance>,
+    pub balances: Mapping<(Id, AccountId), Balance, BalancesKey /* for optimization */>,
+    pub operator_approvals:
+        Mapping<(AccountId, AccountId, Option<Id>), Balance, ApprovalsKey /* for optimization */>,
     pub _reserved: Option<()>,
+}
+
+pub struct BalancesKey;
+
+impl<'a> TypeGuard<'a> for BalancesKey {
+    type Type = &'a (&'a Id, &'a AccountId);
+}
+
+pub struct ApprovalsKey;
+
+impl<'a> TypeGuard<'a> for ApprovalsKey {
+    type Type = &'a (&'a AccountId, &'a AccountId, &'a Option<&'a Id>);
 }
 
 declare_storage_trait!(PSP35Storage, PSP35Data);
@@ -66,8 +82,8 @@ impl<T: PSP35Storage + Flush> PSP35 for T {
         }
     }
 
-    default fn approve(&mut self, operator: AccountId, token: Option<(Id, Balance)>) -> Result<(), PSP35Error> {
-        self._approve_for(operator, token)
+    default fn approve(&mut self, operator: AccountId, id: Option<Id>, value: Balance) -> Result<(), PSP35Error> {
+        self._approve_for(operator, id, value)
     }
 
     default fn transfer(&mut self, to: AccountId, id: Id, value: Balance, data: Vec<u8>) -> Result<(), PSP35Error> {
@@ -134,7 +150,7 @@ pub trait PSP35Internal {
 
     fn _get_allowance(&self, account: &AccountId, operator: &AccountId, id: &Option<&Id>) -> Balance;
 
-    fn _approve_for(&mut self, operator: AccountId, token: Option<(Id, Balance)>) -> Result<(), PSP35Error>;
+    fn _approve_for(&mut self, operator: AccountId, id: Option<Id>, value: Balance) -> Result<(), PSP35Error>;
 
     fn _decrease_allowance(
         &mut self,
@@ -260,12 +276,12 @@ impl<T: PSP35Storage + Flush> PSP35Internal for T {
     }
 
     default fn _balance_of_or_zero(&self, owner: &AccountId, id: &Id) -> Balance {
-        self.get().balances.get((id, owner)).unwrap_or(0)
+        self.get().balances.get(&(id, owner)).unwrap_or(0)
     }
 
     default fn _increase_receiver_balance(&mut self, to: &AccountId, id: &Id, amount: Balance) {
-        let to_balance = self.get_mut().balances.get((id, to)).unwrap_or(0);
-        self.get_mut().balances.insert((id, to), &(to_balance + amount));
+        let to_balance = self.get_mut().balances.get(&(id, to)).unwrap_or(0);
+        self.get_mut().balances.insert(&(id, to), &(to_balance + amount));
     }
 
     default fn _decrease_sender_balance(
@@ -280,58 +296,45 @@ impl<T: PSP35Storage + Flush> PSP35Internal for T {
             return Err(PSP35Error::InsufficientBalance)
         }
 
-        self.get_mut().balances.insert((id, from), &(balance - amount));
+        self.get_mut().balances.insert(&(id, from), &(balance - amount));
         Ok(())
     }
 
     default fn _get_allowance(&self, owner: &AccountId, operator: &AccountId, id: &Option<&Id>) -> Balance {
-        return match self.get().operator_approvals.get((owner, operator, &None)) {
-            None => {
-                let id = <scale::Ref<'_, Option<&Id>, Option<Id>> as From<_>>::from(id);
-                self.get().operator_approvals.get((owner, operator, id)).unwrap_or(0)
-            }
+        return match self.get().operator_approvals.get(&(owner, operator, &None)) {
+            None => self.get().operator_approvals.get(&(owner, operator, id)).unwrap_or(0),
             _ => Balance::MAX,
         }
     }
 
-    fn _approve_for(&mut self, operator: AccountId, token: Option<(Id, Balance)>) -> Result<(), PSP35Error> {
+    fn _approve_for(&mut self, operator: AccountId, id: Option<Id>, value: Balance) -> Result<(), PSP35Error> {
         let caller = Self::env().caller();
 
         if caller == operator {
             return Err(PSP35Error::SelfApprove)
         }
 
-        let (id, value) = match token {
-            Some((token_id, amount)) => ((Some(token_id)), amount),
-            None => (None, Balance::MAX),
-        };
-
-        // TODO: Rework as in PSP35
-        // if let Some((id, value)) = token {
-        //     if value == 0 {
-        //
-        //     } else {
-        //         self.get_mut()
-        //             .operator_approvals
-        //             .insert((caller, operator, &None), &Balance::MAX);
-        //     }
-        //     Some((token_id, amount)) => ((Some(token_id)), amount),
-        //     None => (None, Balance::MAX),
-        // } else {
-        //     self.get_mut()
-        //         .operator_approvals
-        //         .insert((caller, operator, &None), &Balance::MAX);
-        // }
-
-        if value == 0 {
-            self.get_mut().operator_approvals.remove((caller, operator, &id));
+        if let Some(id) = &id {
+            if value == 0 {
+                self.get_mut()
+                    .operator_approvals
+                    .remove(&(&caller, &operator, &Some(id)));
+            } else {
+                self.get_mut()
+                    .operator_approvals
+                    .insert(&(&caller, &operator, &Some(id)), &value);
+            }
         } else {
-            self.get_mut()
-                .operator_approvals
-                .insert((caller, operator, &id), &value);
+            if value == 0 {
+                self.get_mut().operator_approvals.remove(&(&caller, &operator, &None));
+            } else {
+                self.get_mut()
+                    .operator_approvals
+                    .insert(&(&caller, &operator, &None), &Balance::MAX);
+            }
         }
 
-        self._emit_approval_event(caller, operator.clone(), id, value);
+        self._emit_approval_event(caller, operator, id, value);
 
         Ok(())
     }
@@ -359,7 +362,7 @@ impl<T: PSP35Storage + Flush> PSP35Internal for T {
 
         self.get_mut()
             .operator_approvals
-            .insert((owner, operator, Some(id)), &(initial_allowance - value));
+            .insert(&(owner, operator, &Some(id)), &(initial_allowance - value));
 
         Ok(())
     }

--- a/contracts/src/token/psp35/psp35.rs
+++ b/contracts/src/token/psp35/psp35.rs
@@ -50,9 +50,8 @@ pub const STORAGE_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP35Data");
 #[derive(Default, Debug)]
 #[openbrush::storage(STORAGE_KEY)]
 pub struct PSP35Data {
-    pub balances: Mapping<(Id, AccountId), Balance, BalancesKey /* for optimization */>,
-    pub operator_approvals:
-        Mapping<(AccountId, AccountId, Option<Id>), Balance, ApprovalsKey /* for optimization */>,
+    pub balances: Mapping<(Id, AccountId), Balance, BalancesKey /* optimization */>,
+    pub operator_approvals: Mapping<(AccountId, AccountId, Option<Id>), Balance, ApprovalsKey /* optimization */>,
     pub _reserved: Option<()>,
 }
 
@@ -68,9 +67,9 @@ impl<'a> TypeGuard<'a> for ApprovalsKey {
     type Type = &'a (&'a AccountId, &'a AccountId, &'a Option<&'a Id>);
 }
 
-declare_storage_trait!(PSP35Storage, PSP35Data);
+declare_storage_trait!(PSP35Storage);
 
-impl<T: PSP35Storage + Flush> PSP35 for T {
+impl<T: PSP35Storage<Data = PSP35Data> + Flush> PSP35 for T {
     default fn balance_of(&self, owner: AccountId, id: Id) -> Balance {
         self._balance_of_or_zero(&owner, &id)
     }
@@ -179,7 +178,7 @@ pub trait PSP35Internal {
     ) -> Result<(), PSP35Error>;
 }
 
-impl<T: PSP35Storage + Flush> PSP35Internal for T {
+impl<T: PSP35Storage<Data = PSP35Data> + Flush> PSP35Internal for T {
     default fn _emit_transfer_event(
         &self,
         _from: Option<AccountId>,

--- a/contracts/src/traits/psp35/psp35.rs
+++ b/contracts/src/traits/psp35/psp35.rs
@@ -56,7 +56,7 @@ pub trait PSP35 {
     ///
     /// An `Approval` event is emitted.
     #[ink(message)]
-    fn approve(&mut self, operator: AccountId, token: Option<(Id, Balance)>) -> Result<(), PSP35Error>;
+    fn approve(&mut self, operator: AccountId, id: Option<Id>, value: Balance) -> Result<(), PSP35Error>;
 
     /// Transfers `value` of `id` token from `caller` to `to`
     ///

--- a/contracts/src/traits/types.rs
+++ b/contracts/src/traits/types.rs
@@ -21,8 +21,10 @@
 
 use ink_prelude::vec::Vec;
 use ink_primitives::Key;
+
 #[cfg(feature = "std")]
 use ink_storage::traits::StorageLayout;
+
 use ink_storage::traits::{
     ExtKeyPtr,
     KeyPtr,
@@ -44,13 +46,19 @@ pub enum Id {
     Bytes(Vec<u8>),
 }
 
-impl SpreadAllocate for Id {
+impl SpreadAllocate for Id
+where
+    Self: SpreadLayout,
+{
     fn allocate_spread(ptr: &mut KeyPtr) -> Self {
         ptr.next_for::<Id>();
         Id::U8(0)
     }
 }
-impl PackedAllocate for Id {
+impl PackedAllocate for Id
+where
+    Self: PackedLayout,
+{
     #[inline]
     fn allocate_packed(&mut self, _at: &Key) {}
 }

--- a/contracts/src/upgradability/diamond/diamond.rs
+++ b/contracts/src/upgradability/diamond/diamond.rs
@@ -67,11 +67,11 @@ impl<T: DiamondStorage<Data = DiamondData>> OwnableStorage for T {
     type Data = OwnableData;
 
     fn get(&self) -> &Self::Data {
-        &self.get().ownable
+        &DiamondStorage::get(self).ownable
     }
 
     fn get_mut(&mut self) -> &mut Self::Data {
-        &mut self.get_mut().ownable
+        &mut DiamondStorage::get_mut(self).ownable
     }
 }
 

--- a/contracts/src/upgradability/diamond/diamond.rs
+++ b/contracts/src/upgradability/diamond/diamond.rs
@@ -56,23 +56,26 @@ pub struct DiamondData {
     pub hash_to_selectors: Mapping<Hash, Vec<Selector>>,
 }
 
-pub trait DiamondStorage: OwnableStorage + ::openbrush::traits::InkStorage {
-    fn get(&self) -> &DiamondData;
-    fn get_mut(&mut self) -> &mut DiamondData;
+pub trait DiamondStorage: OwnableStorage<Data = OwnableData> + ::openbrush::traits::InkStorage {
+    type Data;
+    fn get(&self) -> &<Self as DiamondStorage>::Data;
+    fn get_mut(&mut self) -> &mut <Self as DiamondStorage>::Data;
 }
 
 #[cfg(not(feature = "proxy"))]
-impl<T: DiamondStorage> OwnableStorage for T {
-    fn get(&self) -> &OwnableData {
-        &DiamondStorage::get(self).ownable
+impl<T: DiamondStorage<Data = DiamondData>> OwnableStorage for T {
+    type Data = OwnableData;
+
+    fn get(&self) -> &Self::Data {
+        &self.get().ownable
     }
 
-    fn get_mut(&mut self) -> &mut OwnableData {
-        &mut DiamondStorage::get_mut(self).ownable
+    fn get_mut(&mut self) -> &mut Self::Data {
+        &mut self.get_mut().ownable
     }
 }
 
-impl<T: DiamondStorage + Flush + DiamondCut> Diamond for T {
+impl<T: DiamondStorage<Data = DiamondData> + Flush + DiamondCut> Diamond for T {
     #[modifiers(only_owner)]
     default fn diamond_cut(&mut self, diamond_cut: Vec<FacetCut>, init: Option<InitCall>) -> Result<(), DiamondError> {
         self._diamond_cut(diamond_cut, init)
@@ -93,7 +96,7 @@ pub trait DiamondInternal {
     fn _emit_diamond_cut_event(&self, diamond_cut: &Vec<FacetCut>, init: &Option<InitCall>);
 }
 
-impl<T: DiamondStorage + Flush + DiamondCut> DiamondInternal for T {
+impl<T: DiamondStorage<Data = DiamondData> + Flush + DiamondCut> DiamondInternal for T {
     default fn _diamond_cut(&mut self, diamond_cut: Vec<FacetCut>, init: Option<InitCall>) -> Result<(), DiamondError> {
         for facet_cut in diamond_cut.iter() {
             let code_hash = facet_cut.hash;

--- a/contracts/src/upgradability/diamond/extensions/diamond_loupe.rs
+++ b/contracts/src/upgradability/diamond/extensions/diamond_loupe.rs
@@ -47,9 +47,9 @@ pub struct DiamondLoupeData {
     pub _reserved: Option<()>,
 }
 
-declare_storage_trait!(DiamondLoupeStorage, DiamondLoupeData);
+declare_storage_trait!(DiamondLoupeStorage);
 
-impl<T: DiamondLoupeStorage> DiamondCut for T {
+impl<T: DiamondLoupeStorage<Data = DiamondLoupeData>> DiamondCut for T {
     default fn _on_add_facet(&mut self, code_hash: Hash) {
         let hash_id = self.get().code_hashes;
         self.get_mut().hash_to_id.insert(&code_hash, &hash_id);
@@ -75,7 +75,7 @@ impl<T: DiamondLoupeStorage> DiamondCut for T {
     }
 }
 
-impl<T: DiamondLoupeStorage + DiamondStorage> DiamondLoupe for T {
+impl<T: DiamondLoupeStorage<Data = DiamondLoupeData> + DiamondStorage<Data = DiamondData>> DiamondLoupe for T {
     default fn facets(&self) -> Vec<FacetCut> {
         let mut out_vec = Vec::new();
         for i in 0..DiamondLoupeStorage::get(self).code_hashes {

--- a/contracts/src/upgradability/proxy/mod.rs
+++ b/contracts/src/upgradability/proxy/mod.rs
@@ -40,23 +40,25 @@ pub struct ProxyData {
     pub forward_to: Hash,
 }
 
-pub trait ProxyStorage: OwnableStorage + ::openbrush::traits::InkStorage {
-    fn get(&self) -> &ProxyData;
-    fn get_mut(&mut self) -> &mut ProxyData;
+pub trait ProxyStorage: OwnableStorage<Data = OwnableData> + ::openbrush::traits::InkStorage {
+    type Data;
+    fn get(&self) -> &<Self as ProxyStorage>::Data;
+    fn get_mut(&mut self) -> &mut <Self as ProxyStorage>::Data;
 }
 
 #[cfg(not(feature = "diamond"))]
-impl<T: ProxyStorage> OwnableStorage for T {
-    fn get(&self) -> &OwnableData {
-        &ProxyStorage::get(self).ownable
+impl<T: ProxyStorage<Data = ProxyData>> OwnableStorage for T {
+    type Data = OwnableData;
+    fn get(&self) -> &Self::Data {
+        &self.get().ownable
     }
 
-    fn get_mut(&mut self) -> &mut OwnableData {
-        &mut ProxyStorage::get_mut(self).ownable
+    fn get_mut(&mut self) -> &mut Self::Data {
+        &mut self.get_mut().ownable
     }
 }
 
-impl<T: ProxyStorage> Proxy for T {
+impl<T: ProxyStorage<Data = ProxyData>> Proxy for T {
     default fn get_delegate_code(&self) -> Hash {
         ProxyStorage::get(self).forward_to
     }
@@ -78,7 +80,7 @@ pub trait ProxyInternal {
     fn _fallback(&self) -> !;
 }
 
-impl<T: ProxyStorage> ProxyInternal for T {
+impl<T: ProxyStorage<Data = ProxyData>> ProxyInternal for T {
     default fn _emit_delegate_code_changed_event(
         &self,
         _previous_code_hash: Option<Hash>,

--- a/contracts/src/upgradability/proxy/mod.rs
+++ b/contracts/src/upgradability/proxy/mod.rs
@@ -50,11 +50,11 @@ pub trait ProxyStorage: OwnableStorage<Data = OwnableData> + ::openbrush::traits
 impl<T: ProxyStorage<Data = ProxyData>> OwnableStorage for T {
     type Data = OwnableData;
     fn get(&self) -> &Self::Data {
-        &self.get().ownable
+        &ProxyStorage::get(self).ownable
     }
 
     fn get_mut(&mut self) -> &mut Self::Data {
-        &mut self.get_mut().ownable
+        &mut ProxyStorage::get_mut(self).ownable
     }
 }
 

--- a/docs/docs/smart-contracts/example/data.md
+++ b/docs/docs/smart-contracts/example/data.md
@@ -107,7 +107,7 @@ Some macros from OpenBrush allows to remove boilerplate code and simplify the de
 macro define the storage like described in the [Storage trait](/smart-contracts/example/data#storage-trait)
 ```rust
 use openbrush::declare_storage_trait;
-declare_storage_trait!(PointStorage, PointData);
+declare_storage_trait!(PointStorage);
 ```
 - [`impl_storage_trait!`](https://github.com/Supercolony-net/openbrush-contracts/blob/main/lang/macro/src/lib.rs)
 macro implements the storage trait for the contract and return the field from that contract of the data type

--- a/example_project_structure/impls/lending/data.rs
+++ b/example_project_structure/impls/lending/data.rs
@@ -56,17 +56,22 @@ pub struct LendingData {
     pub loan_account: AccountId,
 }
 
-declare_storage_trait!(LendingStorage, LendingData);
+declare_storage_trait!(LendingStorage);
 
 /// this internal function will be used to set price of `asset_in` when we deposit `asset_out`
 /// we are using this function in our example to simulate an oracle
-pub fn set_asset_price<T: LendingStorage>(instance: &mut T, asset_in: AccountId, asset_out: AccountId, price: Balance) {
+pub fn set_asset_price<T: LendingStorage<Data = LendingData>>(
+    instance: &mut T,
+    asset_in: AccountId,
+    asset_out: AccountId,
+    price: Balance,
+) {
     instance.get_mut().asset_price.insert((&asset_in, &asset_out), &price);
 }
 
 /// this internal function will be used to set price of `asset_in` when we deposit `asset_out`
 /// we are using this function in our example to simulate an oracle
-pub fn get_asset_price<T: LendingStorage>(
+pub fn get_asset_price<T: LendingStorage<Data = LendingData>>(
     instance: &T,
     amount_in: Balance,
     asset_in: AccountId,
@@ -78,7 +83,7 @@ pub fn get_asset_price<T: LendingStorage>(
 
 /// Internal function which will return the address of the shares token
 /// which are minted when `asset_address` is borrowed
-pub fn get_reserve_asset<T: LendingStorage>(
+pub fn get_reserve_asset<T: LendingStorage<Data = LendingData>>(
     instance: &T,
     asset_address: &AccountId,
 ) -> Result<AccountId, LendingError> {
@@ -95,7 +100,7 @@ pub fn get_reserve_asset<T: LendingStorage>(
 
 /// internal function which will return the address of asset
 /// which is bound to `shares_address` shares token
-pub fn get_asset_from_shares<T: LendingStorage>(
+pub fn get_asset_from_shares<T: LendingStorage<Data = LendingData>>(
     instance: &T,
     shares_address: AccountId,
 ) -> Result<AccountId, LendingError> {

--- a/example_project_structure/impls/lending/lending.rs
+++ b/example_project_structure/impls/lending/lending.rs
@@ -30,7 +30,7 @@ use openbrush::{
 
 pub const YEAR: Timestamp = 60 * 60 * 24 * 365;
 
-impl<T: LendingStorage + PausableStorage> Lending for T {
+impl<T: LendingStorage<Data = LendingData> + PausableStorage<Data = PausableData>> Lending for T {
     default fn total_asset(&self, asset_address: AccountId) -> Result<Balance, LendingError> {
         // get asset from mapping
         let mapped_asset = LendingStorage::get(self)

--- a/examples/psp22_extensions/pausable/lib.rs
+++ b/examples/psp22_extensions/pausable/lib.rs
@@ -3,6 +3,7 @@
 
 #[openbrush::contract]
 pub mod my_psp22_pausable {
+    use ink_storage::traits::SpreadAllocate;
     use openbrush::{
         contracts::{
             pausable::*,
@@ -10,7 +11,6 @@ pub mod my_psp22_pausable {
         },
         modifiers,
     };
-    use ink_storage::traits::SpreadAllocate;
 
     #[ink(storage)]
     #[derive(Default, SpreadAllocate, PSP22Storage, PausableStorage)]

--- a/examples/psp34_extensions/enumerable/lib.rs
+++ b/examples/psp34_extensions/enumerable/lib.rs
@@ -10,13 +10,11 @@ pub mod my_psp34_enumerable {
         mintable::*,
     };
 
-    #[derive(Default, SpreadAllocate, PSP34Storage, PSP34EnumerableStorage)]
+    #[derive(Default, SpreadAllocate, PSP34Storage)]
     #[ink(storage)]
     pub struct MyPSP34 {
         #[PSP34StorageField]
-        psp34: PSP34Data,
-        #[PSP34EnumerableStorageField]
-        enumerable: PSP34EnumerableData,
+        psp34: PSP34Data<EnumerableBalances>,
     }
 
     impl PSP34 for MyPSP34 {}

--- a/examples/reentrancy_guard/traits/flipper.rs
+++ b/examples/reentrancy_guard/traits/flipper.rs
@@ -13,7 +13,7 @@ pub trait FlipperStorage {
 pub type FlipperRef = dyn Flipper;
 
 #[openbrush::trait_definition]
-pub trait Flipper: FlipperStorage + ReentrancyGuardStorage {
+pub trait Flipper: FlipperStorage + ReentrancyGuardStorage<Data = ReentrancyGuardData> {
     #[ink(message)]
     fn get_value(&self) -> bool {
         self.value().clone()

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -20,6 +20,7 @@ ink_env = { version = "~3.2.0", default-features = false }
 ink_lang = { version = "~3.2.0", default-features = false }
 ink_primitives = { version = "~3.2.0", default-features = false }
 ink_storage = { version = "~3.2.0", default-features = false }
+ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"] }
@@ -39,6 +40,7 @@ std = [
     "ink_lang/std",
     "ink_primitives/std",
     "ink_storage/std",
+    "ink_metadata/std",
     "scale/std",
     "scale-info/std",
 ]

--- a/lang/src/derive.rs
+++ b/lang/src/derive.rs
@@ -75,11 +75,13 @@ macro_rules! declare_derive_storage_trait {
 
             let code = quote::quote! {
                 impl $trait_name for #struct_ident {
-                    fn get(&self) -> & #field_ty {
+                    type Data = #field_ty;
+
+                    fn get(&self) -> &<Self as $trait_name>::Data {
                         &self.#field_ident
                     }
 
-                    fn get_mut(&mut self) -> &mut #field_ty {
+                    fn get_mut(&mut self) -> &mut <Self as $trait_name>::Data {
                         &mut self.#field_ident
                     }
                 }

--- a/lang/src/macros.rs
+++ b/lang/src/macros.rs
@@ -19,19 +19,18 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/// This `macro_rule` defines the storage trait.
-///
-/// The first argument is the name of the storage trait.
-/// The second argument is the type of storage data, which will be returned by this trait.
+/// This `macro_rule` defines the storage trait. It accepts only one argument -
+/// the name of the storage trait.
 ///
 /// An example of the usage of this macro can be found in any contract implemented by this library.
 /// For example [OwnableStorage](ownable::OwnableStorage).
 #[macro_export]
 macro_rules! declare_storage_trait {
-    ($trait_name:ident,$data_ty:ty) => {
+    ($trait_name:ident) => {
         pub trait $trait_name: ::openbrush::traits::InkStorage {
-            fn get(&self) -> &$data_ty;
-            fn get_mut(&mut self) -> &mut $data_ty;
+            type Data;
+            fn get(&self) -> &Self::Data;
+            fn get_mut(&mut self) -> &mut Self::Data;
         }
     };
 }
@@ -48,11 +47,12 @@ macro_rules! declare_storage_trait {
 macro_rules! impl_storage_trait {
     ($trait_name:ident,$struct_name:ident,$field:ident,$data_ty:ty) => {
         impl $trait_name for $struct_name {
-            fn get(&self) -> &$data_ty {
+            type Data = $data_ty;
+            fn get(&self) -> &Self::Data {
                 &self.$field
             }
 
-            fn get_mut(&mut self) -> &mut $data_ty {
+            fn get_mut(&mut self) -> &mut Self::Data {
                 &mut self.$field
             }
         }

--- a/lang/src/storage/helper.rs
+++ b/lang/src/storage/helper.rs
@@ -1,0 +1,167 @@
+// Copyright 2018-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! A simple Helper to contract storage.
+//!
+//! # Note
+//!
+//! This Helper doesn't actually "own" any data.
+//! Instead it is just a simple wrapper around the contract storage facilities.
+
+use core::marker::PhantomData;
+use ink_storage::traits::{
+    push_packed_root,
+    PackedLayout,
+    SpreadLayout,
+};
+
+use ink_env::hash::{
+    Blake2x256,
+    HashOutput,
+};
+use ink_primitives::Key;
+
+pub struct Helper<K, V, T = Key> {
+    prefix: T,
+    _marker: PhantomData<fn() -> (K, V)>,
+}
+
+// TODO: Doc
+impl<K, V, T> Helper<K, V, T> {
+    /// Creates a new empty `Helper`.
+    #[inline(always)]
+    pub fn new(prefix: T) -> Self {
+        Self {
+            prefix,
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<K, V, T> Helper<K, V, T>
+where
+    T: scale::Encode + Copy,
+{
+    /// Insert the given `value` to the contract storage.
+    #[inline(always)]
+    pub fn insert(&self, key: K, value: &V)
+    where
+        K: scale::Encode,
+        V: PackedLayout,
+    {
+        self.insert_return_size(key, value);
+    }
+
+    /// Insert the given `value` to the contract storage.
+    ///
+    /// Returns the size of the pre-existing value at the specified key if any.
+    #[inline(always)]
+    pub fn insert_return_size(&self, key: K, value: &V) -> Option<u32>
+    where
+        K: scale::Encode,
+        V: PackedLayout,
+    {
+        push_packed_root(value, &self.storage_key(key))
+    }
+
+    /// Get the `value` at `key` from the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given `key`.
+    #[inline(always)]
+    pub fn get(&self, key: K) -> Option<V>
+    where
+        K: scale::Encode,
+        V: PackedLayout,
+    {
+        self.get_contract_storage(&self.storage_key(key))
+    }
+
+    /// Get the size of a value stored at `key` in the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given `key`.
+    #[inline(always)]
+    pub fn size(&self, key: K) -> Option<u32>
+    where
+        K: scale::Encode,
+    {
+        ink_env::contract_storage_contains(&self.storage_key(key))
+    }
+
+    /// Checks if a value is stored at the given `key` in the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given `key`.
+    #[inline(always)]
+    pub fn contains(&self, key: K) -> bool
+    where
+        K: scale::Encode,
+    {
+        ink_env::contract_storage_contains(&self.storage_key(key)).is_some()
+    }
+
+    /// Clears the value at `key` from storage.
+    #[inline(always)]
+    pub fn remove(&self, key: K)
+    where
+        K: scale::Encode,
+        V: PackedLayout,
+    {
+        let storage_key = self.storage_key(key);
+        if <V as SpreadLayout>::REQUIRES_DEEP_CLEAN_UP {
+            // There are types which need to perform some action before being cleared. Here we
+            // indicate to those types that they should start tidying up.
+            if let Some(value) = self.get_contract_storage(&storage_key) {
+                <V as PackedLayout>::clear_packed(&value, &storage_key);
+            }
+        }
+        ink_env::clear_contract_storage(&storage_key);
+    }
+
+    /// Returns a `Key` pointer used internally by the storage API.
+    ///
+    /// This key is a combination of the `Helper`'s internal `offset_key`
+    /// and the user provided `key`.
+    #[inline(always)]
+    fn storage_key(&self, key: K) -> Key
+    where
+        K: scale::Encode,
+    {
+        let encodedable_key = (self.prefix, key);
+        Self::storage_key_inline(&encodedable_key)
+    }
+
+    #[inline(never)]
+    fn storage_key_inline<E>(key: &E) -> Key
+    where
+        E: scale::Encode,
+    {
+        let mut output = <Blake2x256 as HashOutput>::Type::default();
+        ink_env::hash_encoded::<Blake2x256, _>(key, &mut output);
+        output.into()
+    }
+
+    fn get_contract_storage(&self, key: &Key) -> Option<V>
+    where
+        K: scale::Encode,
+        V: PackedLayout,
+    {
+        ink_env::get_contract_storage::<V>(key)
+            .unwrap_or_else(|error| panic!("failed to pull packed from root key {}: {:?}", key, error))
+            .map(|mut value| {
+                // In case the contract storage is occupied at the root key
+                // we handle the Option<T> as if it was a T.
+                <V as PackedLayout>::pull_packed(&mut value, key);
+                value
+            })
+    }
+}

--- a/lang/src/storage/mapping.rs
+++ b/lang/src/storage/mapping.rs
@@ -204,3 +204,36 @@ const _: () = {
         }
     }
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[ink_lang::test]
+    fn insert_and_get_work() {
+        let mut mapping: Mapping<u128, u128> = Mapping::default();
+
+        mapping.insert(&1, &1);
+        mapping.insert(&2, &2);
+
+        assert_eq!(mapping.get(&1), Some(1));
+        assert_eq!(mapping.get(&2), Some(2));
+        assert_eq!(mapping.get(&3), None);
+    }
+
+    #[ink_lang::test]
+    fn remove_and_contains_works() {
+        let mut mapping: Mapping<u128, u128> = Mapping::default();
+
+        mapping.insert(&1, &1);
+        mapping.insert(&2, &2);
+
+        assert_eq!(mapping.contains(&1), true);
+        assert_eq!(mapping.contains(&2), true);
+
+        mapping.remove(&1);
+
+        assert_eq!(mapping.contains(&1), false);
+        assert_eq!(mapping.contains(&2), true);
+    }
+}

--- a/lang/src/storage/mapping.rs
+++ b/lang/src/storage/mapping.rs
@@ -1,0 +1,199 @@
+// Copyright 2018-2022 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{
+    Helper,
+    TypeGuard,
+    ValueGuard,
+};
+use core::marker::PhantomData;
+use ink_storage::traits::{
+    ExtKeyPtr,
+    KeyPtr,
+    PackedLayout,
+    SpreadAllocate,
+    SpreadLayout,
+};
+
+use crate::storage::RefGuard;
+use ink_primitives::Key;
+
+/// It is a more restricted version of the `Mapping` from ink!. That mapping can be used to unify
+/// the API calls to the `Mapping` to avoid monomorphization to reduce the size of contracts.
+/// It verifies that all calls are done with the same type during compilation.
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct Mapping<K, V, TGK = RefGuard<K>, TGV = ValueGuard<V>> {
+    offset_key: Key,
+    _marker: PhantomData<fn() -> (K, V, TGK, TGV)>,
+}
+
+/// We implement this manually because the derived implementation adds trait bounds.
+impl<K, V, TGK, TGV> Default for Mapping<K, V, TGK, TGV> {
+    fn default() -> Self {
+        Self {
+            offset_key: Default::default(),
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<K, V, TGK, TGV> core::fmt::Debug for Mapping<K, V, TGK, TGV> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("Mapping").field("offset_key", &self.offset_key).finish()
+    }
+}
+
+impl<K, V, TGK, TGV> Mapping<K, V, TGK, TGV> {
+    /// Creates a new empty `Mapping`.
+    fn new(offset_key: Key) -> Self {
+        Self {
+            offset_key,
+            _marker: Default::default(),
+        }
+    }
+}
+
+impl<K, V, TGK, TGV> Mapping<K, V, TGK, TGV>
+where
+    K: PackedLayout,
+    V: PackedLayout,
+{
+    /// Insert the given `value` to the contract storage.
+    #[inline]
+    pub fn insert<'a, 'b>(&mut self, key: TGK::Type, value: &TGV::Type)
+    where
+        TGK: TypeGuard<'a>,
+        TGV: TypeGuard<'b>,
+        TGK::Type: scale::Encode,
+        TGV::Type: PackedLayout,
+    {
+        Helper::<TGK::Type, TGV::Type, &Key>::new(&self.offset_key).insert(key, value)
+    }
+
+    /// Insert the given `value` to the contract storage.
+    ///
+    /// Returns the size of the pre-existing value at the specified key if any.
+    #[inline]
+    pub fn insert_return_size<'a, 'b>(&mut self, key: TGK::Type, value: &TGV::Type) -> Option<u32>
+    where
+        TGK: TypeGuard<'a>,
+        TGV: TypeGuard<'b>,
+        TGK::Type: scale::Encode,
+        TGV::Type: PackedLayout,
+    {
+        Helper::<TGK::Type, TGV::Type, &Key>::new(&self.offset_key).insert_return_size(key, value)
+    }
+
+    /// Get the `value` at `key` from the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given `key`.
+    #[inline]
+    pub fn get<'a>(&self, key: TGK::Type) -> Option<V>
+    where
+        TGK: TypeGuard<'a>,
+        TGK::Type: scale::Encode,
+    {
+        Helper::<TGK::Type, V, &Key>::new(&self.offset_key).get(key)
+    }
+
+    /// Get the size of a value stored at `key` in the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given `key`.
+    #[inline]
+    pub fn size<'a>(&self, key: TGK::Type) -> Option<u32>
+    where
+        TGK: TypeGuard<'a>,
+        TGK::Type: scale::Encode,
+    {
+        Helper::<TGK::Type, (), &Key>::new(&self.offset_key).size(key)
+    }
+
+    /// Checks if a value is stored at the given `key` in the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given `key`.
+    #[inline]
+    pub fn contains<'a>(&self, key: TGK::Type) -> bool
+    where
+        TGK: TypeGuard<'a>,
+        TGK::Type: scale::Encode,
+    {
+        Helper::<TGK::Type, (), &Key>::new(&self.offset_key).contains(key)
+    }
+
+    /// Clears the value at `key` from storage.
+    pub fn remove<'a>(&self, key: TGK::Type)
+    where
+        TGK: TypeGuard<'a>,
+        TGK::Type: scale::Encode,
+    {
+        Helper::<TGK::Type, V, &Key>::new(&self.offset_key).remove(key)
+    }
+}
+
+impl<K, V, TGK, TGV> SpreadLayout for Mapping<K, V, TGK, TGV> {
+    const FOOTPRINT: u64 = 1;
+    const REQUIRES_DEEP_CLEAN_UP: bool = false;
+
+    #[inline(always)]
+    fn pull_spread(ptr: &mut KeyPtr) -> Self {
+        // Note: There is no need to pull anything from the storage for the
+        //       mapping type since it initializes itself entirely by the
+        //       given key pointer.
+        Self::new(*ExtKeyPtr::next_for::<Self>(ptr))
+    }
+
+    #[inline(always)]
+    fn push_spread(&self, ptr: &mut KeyPtr) {
+        // Note: The mapping type does not store any state in its associated
+        //       storage region, therefore only the pointer has to be incremented.
+        ptr.advance_by(Self::FOOTPRINT);
+    }
+
+    #[inline(always)]
+    fn clear_spread(&self, ptr: &mut KeyPtr) {
+        // Note: The mapping type is not aware of its elements, therefore
+        //       it is not possible to clean up after itself.
+        ptr.advance_by(Self::FOOTPRINT);
+    }
+}
+
+impl<K, V, TGK, TGV> SpreadAllocate for Mapping<K, V, TGK, TGV> {
+    #[inline(always)]
+    fn allocate_spread(ptr: &mut KeyPtr) -> Self {
+        // Note: The mapping type initializes itself entirely by the key pointer.
+        Self::new(*ExtKeyPtr::next_for::<Self>(ptr))
+    }
+}
+
+#[cfg(feature = "std")]
+const _: () = {
+    use ink_metadata::layout::{
+        CellLayout,
+        Layout,
+        LayoutKey,
+    };
+    use ink_storage::traits::StorageLayout;
+
+    impl<K, V, TGK, TGV> StorageLayout for Mapping<K, V, TGK, TGV>
+    where
+        K: scale_info::TypeInfo + 'static,
+        V: scale_info::TypeInfo + 'static,
+    {
+        fn layout(key_ptr: &mut KeyPtr) -> Layout {
+            Layout::Cell(CellLayout::new::<ink_storage::Mapping<K, V>>(LayoutKey::from(
+                key_ptr.advance_by(1),
+            )))
+        }
+    }
+};

--- a/lang/src/storage/mod.rs
+++ b/lang/src/storage/mod.rs
@@ -19,6 +19,32 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+use core::marker::PhantomData;
+
+mod helper;
+mod mapping;
 mod multiple_value_mapping;
 
+pub use helper::Helper;
+pub use mapping::Mapping;
 pub use multiple_value_mapping::MultipleValueMapping;
+
+pub trait TypeGuard<'a> {
+    type Type: 'a;
+}
+
+impl<'a> TypeGuard<'a> for () {
+    type Type = ();
+}
+
+pub struct ValueGuard<K>(PhantomData<K>);
+
+impl<'a, K: 'a> TypeGuard<'a> for ValueGuard<K> {
+    type Type = K;
+}
+
+pub struct RefGuard<K>(PhantomData<K>);
+
+impl<'a, K: 'a> TypeGuard<'a> for RefGuard<K> {
+    type Type = &'a K;
+}

--- a/lang/src/storage/mod.rs
+++ b/lang/src/storage/mod.rs
@@ -19,19 +19,6 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+mod multiple_value_mapping;
 
-pub mod derive;
-mod macros;
-pub mod storage;
-pub mod test_utils;
-pub mod traits;
-
-pub use openbrush_lang_macro::{
-    contract,
-    modifier_definition,
-    modifiers,
-    storage,
-    trait_definition,
-    wrapper,
-};
+pub use multiple_value_mapping::MultipleValueMapping;

--- a/lang/src/storage/multiple_value_mapping.rs
+++ b/lang/src/storage/multiple_value_mapping.rs
@@ -1,0 +1,407 @@
+// Copyright (c) 2012-2022 Supercolony
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the"Software"),
+// to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use ink_storage::{
+    traits::{
+        PackedLayout,
+        SpreadAllocate,
+        SpreadLayout,
+    },
+    Mapping,
+};
+use scale::Ref;
+
+/// A mapping of key-value pairs directly into contract storage.
+///
+/// # Important
+///
+/// If you use this data structure you must use the function
+/// [`ink_lang::utils::initialize_contract`](https://paritytech.github.io/ink/ink_lang/utils/fn.initialize_contract.html)
+/// in your contract's constructors!
+///
+/// Note that in order to use this function your contract's storage struct must implement the
+/// [`SpreadAllocate`](crate::traits::SpreadAllocate) trait.
+///
+/// This is an example of how you can do this:
+/// ```rust
+/// # use ink_lang as ink;
+/// # use ink_env::{
+/// #     Environment,
+/// #     DefaultEnvironment,
+/// # };
+/// # type AccountId = <DefaultEnvironment as Environment>::AccountId;
+///
+/// # #[ink::contract]
+/// # mod my_module {
+/// use ink_storage::{traits::SpreadAllocate, Mapping};
+///
+/// #[ink(storage)]
+/// #[derive(SpreadAllocate)]
+/// pub struct MyContract {
+///     balances: Mapping<AccountId, Balance>,
+/// }
+///
+/// impl MyContract {
+///     #[ink(constructor)]
+///     pub fn new() -> Self {
+///         ink_lang::utils::initialize_contract(Self::new_init)
+///     }
+///
+///     /// Default initializes the contract.
+///     fn new_init(&mut self) {
+///         let caller = Self::env().caller();
+///         let value: Balance = Default::default();
+///         self.balances.insert(&caller, &value);
+///     }
+/// #   #[ink(message)]
+/// #   pub fn my_message(&self) { }
+/// }
+/// # }
+/// ```
+///
+/// More usage examples can be found [in the ink! examples](https://github.com/paritytech/ink/tree/master/examples).
+#[derive(SpreadLayout, SpreadAllocate)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct MultipleValueMapping<K, V> {
+    /// Contains count of values by key.
+    key_count: Mapping<K, u128>,
+    /// Mapping from key's value to local index.
+    value_to_index: Mapping<(K, V), u128>,
+    /// Mapping from local key's index to value.
+    index_to_value: Mapping<(K, u128), V>,
+}
+
+impl<K, V> Default for MultipleValueMapping<K, V> {
+    fn default() -> Self {
+        Self {
+            key_count: Default::default(),
+            value_to_index: Default::default(),
+            index_to_value: Default::default(),
+        }
+    }
+}
+
+impl<K, V> core::fmt::Debug for MultipleValueMapping<K, V> {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("MultipleValueMapping")
+            .field("key_count", &self.key_count)
+            .field("value_to_index", &self.value_to_index)
+            .field("index_to_value", &self.index_to_value)
+            .finish()
+    }
+}
+
+impl<K, V> MultipleValueMapping<K, V>
+where
+    K: PackedLayout,
+    V: PackedLayout,
+    V: scale::EncodeLike<V>,
+{
+    /// Insert the given `value` to the contract storage at `key`.
+    pub fn insert<Q, R>(&mut self, key: &Q, value: &R)
+    where
+        Q: scale::EncodeLike<K>,
+        R: scale::EncodeLike<V> + PackedLayout,
+    {
+        self.insert_return_size::<Q, R>(key, value);
+    }
+
+    /// Insert the given `value` to the contract storage at `key`.
+    ///
+    /// Returns the size of the pre-existing value at the specified key if any.
+    pub fn insert_return_size<Q, R>(&mut self, key: &Q, value: &R) -> Option<u32>
+    where
+        Q: scale::EncodeLike<K>,
+        R: scale::EncodeLike<V> + PackedLayout,
+    {
+        let count = self.count::<Q>(key);
+        self.value_to_index.insert(
+            (
+                <Ref<'_, Q, K> as From<_>>::from(key),
+                <Ref<'_, R, V> as From<_>>::from(value),
+            ),
+            &count,
+        );
+        self.index_to_value
+            .insert_return_size((<Ref<'_, Q, K> as From<_>>::from(key), &count), value)
+    }
+
+    /// Returns the count of values stored under the `key`.
+    #[inline]
+    pub fn count<Q>(&self, key: &Q) -> u128
+    where
+        Q: scale::EncodeLike<K>,
+    {
+        self.key_count
+            .get(<Ref<'_, Q, K> as From<_>>::from(key))
+            .unwrap_or_default()
+    }
+
+    /// Get the `value` at (`key`, `index`) from the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given (`key`, `index`).
+    #[inline]
+    pub fn get_value<Q>(&self, key: &Q, index: &u128) -> Option<V>
+    where
+        Q: scale::EncodeLike<K>,
+    {
+        self.index_to_value.get((<Ref<'_, Q, K> as From<_>>::from(key), index))
+    }
+
+    /// Get the `index` of (`key`, `value`) from the contract storage.
+    ///
+    /// Returns `None` if no `value` exists for the given `key`.
+    #[inline]
+    pub fn get_index<Q, R>(&self, key: &Q, value: &R) -> Option<u128>
+    where
+        Q: scale::EncodeLike<K>,
+        R: scale::EncodeLike<V>,
+    {
+        self.value_to_index.get((
+            <Ref<'_, Q, K> as From<_>>::from(key),
+            <Ref<'_, R, V> as From<_>>::from(value),
+        ))
+    }
+
+    /// Get the size of a value stored at (`key`, `index`) in the contract storage.
+    ///
+    /// Returns `None` if no `value` exists at the given (`key`, `index`).
+    #[inline]
+    pub fn size<Q>(&self, key: &Q, index: &u128) -> Option<u32>
+    where
+        Q: scale::EncodeLike<K>,
+    {
+        self.index_to_value.size((<Ref<'_, Q, K> as From<_>>::from(key), index))
+    }
+
+    /// Checks if any value is stored at the given `key` in the contract storage.
+    #[inline]
+    pub fn contains<Q>(&self, key: &Q) -> bool
+    where
+        Q: scale::EncodeLike<K>,
+    {
+        self.count::<Q>(key) > 0
+    }
+
+    /// Checks if the `value` is stored at the given `key` in the contract storage.
+    #[inline]
+    pub fn contains_value<Q, R>(&self, key: &Q, value: &R) -> bool
+    where
+        Q: scale::EncodeLike<K>,
+        R: scale::EncodeLike<V>,
+    {
+        self.value_to_index.contains((
+            <Ref<'_, Q, K> as From<_>>::from(key),
+            <Ref<'_, R, V> as From<_>>::from(value),
+        ))
+    }
+
+    /// Checks if any value is stored at the given (`key`, `index`) in the contract storage.
+    #[inline]
+    pub fn contains_index<Q>(&self, key: &Q, index: &u128) -> bool
+    where
+        Q: scale::EncodeLike<K>,
+    {
+        self.index_to_value
+            .contains((<Ref<'_, Q, K> as From<_>>::from(key), index))
+    }
+
+    /// Clears the `value` at `key` from storage.
+    pub fn remove_value<Q, R>(&mut self, key: &Q, value: &R)
+    where
+        Q: scale::EncodeLike<K>,
+        R: scale::EncodeLike<V>,
+        V: scale::EncodeLike<V>,
+    {
+        let op_index = self.get_index::<Q, R>(key, value);
+
+        let index;
+        if let Some(op_index) = op_index {
+            index = op_index;
+        } else {
+            return
+        }
+        let index = &index;
+        self.swap_and_remove::<Q, R>(key, value, index);
+    }
+
+    /// Clears the value at (`key`, `index`) from storage.
+    pub fn remove_index<Q>(&mut self, key: &Q, index: &u128)
+    where
+        Q: scale::EncodeLike<K>,
+    {
+        let op_value = self.get_value::<Q>(key, index);
+
+        let value;
+        if let Some(op_value) = op_value {
+            value = op_value;
+        } else {
+            return
+        }
+        let value = &value;
+        self.swap_and_remove::<Q, V>(key, value, index);
+    }
+
+    fn swap_and_remove<Q, R>(&mut self, key: &Q, value: &R, index: &u128)
+    where
+        Q: scale::EncodeLike<K>,
+        R: scale::EncodeLike<V>,
+    {
+        let last_index = &self.count(key);
+
+        if last_index != index {
+            let last_value = &self
+                .index_to_value
+                .get((<Ref<'_, Q, K> as From<_>>::from(key), &last_index))
+                .expect("The value under the last index should exist");
+            self.index_to_value
+                .insert((<Ref<'_, Q, K> as From<_>>::from(key), &index), last_value);
+            self.value_to_index.insert(
+                (
+                    <Ref<'_, Q, K> as From<_>>::from(key),
+                    <Ref<'_, V, V> as From<_>>::from(last_value),
+                ),
+                index,
+            );
+        }
+
+        self.index_to_value
+            .remove((<Ref<'_, Q, K> as From<_>>::from(key), &last_index));
+        self.value_to_index.remove((
+            <Ref<'_, Q, K> as From<_>>::from(key),
+            <Ref<'_, R, V> as From<_>>::from(value),
+        ));
+    }
+}
+
+#[cfg(feature = "std")]
+const _: () = {
+    use ink_metadata::layout::{
+        FieldLayout,
+        Layout,
+        StructLayout,
+    };
+    use ink_primitives::KeyPtr;
+    use ink_storage::traits::StorageLayout;
+
+    impl<K, V> StorageLayout for MultipleValueMapping<K, V>
+    where
+        K: scale_info::TypeInfo + 'static,
+        V: scale_info::TypeInfo + 'static,
+    {
+        fn layout(key_ptr: &mut KeyPtr) -> Layout {
+            Layout::Struct(StructLayout::new([
+                FieldLayout::new(
+                    Some("key_count"),
+                    <Mapping<K, u128> as ::ink_storage::traits::StorageLayout>::layout(key_ptr),
+                ),
+                FieldLayout::new(
+                    Some("value_to_index"),
+                    <Mapping<(K, V), u128> as ::ink_storage::traits::StorageLayout>::layout(key_ptr),
+                ),
+                FieldLayout::new(
+                    Some("index_to_value"),
+                    <Mapping<(K, u128), V> as ::ink_storage::traits::StorageLayout>::layout(key_ptr),
+                ),
+            ]))
+        }
+    }
+};
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//
+//     #[test]
+//     fn insert_and_get_work() {
+//         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+//             let mut mapping: Mapping<u8, _> = Mapping::new([0u8; 32].into());
+//             mapping.insert(&1, &2);
+//             assert_eq!(mapping.get(&1), Some(2));
+//
+//             Ok(())
+//         })
+//         .unwrap()
+//     }
+//
+//     #[test]
+//     fn gets_default_if_no_key_set() {
+//         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+//             let mapping: Mapping<u8, u8> = Mapping::new([0u8; 32].into());
+//             assert_eq!(mapping.get(&1), None);
+//
+//             Ok(())
+//         })
+//         .unwrap()
+//     }
+//
+//     #[test]
+//     fn can_clear_entries() {
+//         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+//             // We use `Pack` here since it `REQUIRES_DEEP_CLEAN_UP`
+//             use crate::pack::Pack;
+//
+//             // Given
+//             let mut mapping: Mapping<u8, u8> = Mapping::new([0u8; 32].into());
+//             let mut deep_mapping: Mapping<u8, Pack<u8>> = Mapping::new([1u8; 32].into());
+//
+//             mapping.insert(&1, &2);
+//             assert_eq!(mapping.get(&1), Some(2));
+//
+//             deep_mapping.insert(&1u8, &Pack::new(Pack::new(2u8)));
+//             assert_eq!(deep_mapping.get(&1), Some(Pack::new(2u8)));
+//
+//             // When
+//             mapping.remove(&1);
+//             deep_mapping.remove(&1);
+//
+//             // Then
+//             assert_eq!(mapping.get(&1), None);
+//             assert_eq!(deep_mapping.get(&1), None);
+//
+//             Ok(())
+//         })
+//         .unwrap()
+//     }
+//
+//     #[test]
+//     fn can_clear_unexistent_entries() {
+//         ink_env::test::run_test::<ink_env::DefaultEnvironment, _>(|_| {
+//             // We use `Pack` here since it `REQUIRES_DEEP_CLEAN_UP`
+//             use crate::pack::Pack;
+//
+//             // Given
+//             let mapping: Mapping<u8, u8> = Mapping::new([0u8; 32].into());
+//             let deep_mapping: Mapping<u8, Pack<u8>> = Mapping::new([1u8; 32].into());
+//
+//             // When
+//             mapping.remove(&1);
+//             deep_mapping.remove(&1);
+//
+//             // Then
+//             assert_eq!(mapping.get(&1), None);
+//             assert_eq!(deep_mapping.get(&1), None);
+//
+//             Ok(())
+//         })
+//         .unwrap()
+//     }
+// }

--- a/lang/src/storage/multiple_value_mapping.rs
+++ b/lang/src/storage/multiple_value_mapping.rs
@@ -350,4 +350,71 @@ const _: () = {
     }
 };
 
-// TODO: Tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[ink_lang::test]
+    fn insert_and_count_works() {
+        let mut mapping: MultipleValueMapping<u128, u128> = MultipleValueMapping::default();
+        mapping.insert(&1, &1);
+        mapping.insert(&1, &2);
+        assert_eq!(mapping.count(&1), 2);
+    }
+
+    #[ink_lang::test]
+    fn get_works() {
+        let mut mapping: MultipleValueMapping<u128, u128> = MultipleValueMapping::default();
+        mapping.insert(&1, &1);
+        assert_eq!(mapping.get_index(&1, &1), Some(0));
+        assert_eq!(mapping.get_value(&1, &0), Some(1));
+
+        mapping.insert(&1, &2);
+        assert_eq!(mapping.get_index(&1, &1), Some(0));
+        assert_eq!(mapping.get_index(&1, &2), Some(1));
+
+        assert_eq!(mapping.get_value(&1, &0), Some(1));
+        assert_eq!(mapping.get_value(&1, &1), Some(2));
+    }
+
+    #[ink_lang::test]
+    fn remove_works() {
+        let mut mapping: MultipleValueMapping<u128, u128> = MultipleValueMapping::default();
+        mapping.insert(&1, &1);
+        mapping.insert(&1, &2);
+        assert_eq!(mapping.get_index(&1, &1), Some(0));
+        assert_eq!(mapping.get_index(&1, &2), Some(1));
+
+        assert_eq!(mapping.count(&1), 2);
+
+        mapping.remove_value(&1, &1);
+        assert_eq!(mapping.count(&1), 1);
+        assert_eq!(mapping.get_value(&1, &0), Some(2));
+
+        mapping.insert(&1, &1);
+
+        assert_eq!(mapping.count(&1), 2);
+        assert_eq!(mapping.get_value(&1, &0), Some(2));
+        assert_eq!(mapping.get_value(&1, &1), Some(1));
+
+        mapping.remove_index(&1, &0);
+
+        assert_eq!(mapping.count(&1), 1);
+        assert_eq!(mapping.get_value(&1, &0), Some(1));
+    }
+
+    #[ink_lang::test]
+    fn contain_works() {
+        let mut mapping: MultipleValueMapping<u128, u128> = MultipleValueMapping::default();
+
+        mapping.insert(&1, &1);
+        mapping.insert(&1, &2);
+
+        assert_eq!(mapping.contain(&1), true);
+        assert_eq!(mapping.contain(&2), false);
+        assert_eq!(mapping.contains_index(&1, &1), true);
+        assert_eq!(mapping.contains_index(&1, &2), false);
+        assert_eq!(mapping.contains_value(&1, &1), true);
+        assert_eq!(mapping.contains_value(&1, &3), false);
+    }
+}

--- a/tests/diamond_loupe.rs
+++ b/tests/diamond_loupe.rs
@@ -48,6 +48,7 @@ mod diamond {
     }
 
     impl OwnableStorage for DiamondContract {
+        type Data = OwnableData;
         fn get(&self) -> &OwnableData {
             &self.diamond.ownable
         }

--- a/tests/e2e/psp35/extensions/batch.tests.ts
+++ b/tests/e2e/psp35/extensions/batch.tests.ts
@@ -100,7 +100,7 @@ describe('MY_PSP35_BATCH', () => {
     const amount2 = 20
 
     await expect(tx.mint(sender.address, [[token1, amount1], [token2, amount2]], [])).to.eventually.be.fulfilled
-    await expect(tx.approve(alice.address, null, '340282366920938463463374607431768211455')).to.eventually.be.fulfilled
+    await expect(tx.approve(alice.address, null, 1)).to.eventually.be.fulfilled
 
     await expect(fromSigner(contract, alice.address).tx.batchTransferFrom(sender.address, alice.address, [[token1, amount1], [token2, amount2]], [])).to.eventually.be.fulfilled
 

--- a/tests/e2e/psp35/extensions/batch.tests.ts
+++ b/tests/e2e/psp35/extensions/batch.tests.ts
@@ -100,7 +100,7 @@ describe('MY_PSP35_BATCH', () => {
     const amount2 = 20
 
     await expect(tx.mint(sender.address, [[token1, amount1], [token2, amount2]], [])).to.eventually.be.fulfilled
-    await expect(tx.approve(alice.address, null)).to.eventually.be.fulfilled
+    await expect(tx.approve(alice.address, null, '340282366920938463463374607431768211455')).to.eventually.be.fulfilled
 
     await expect(fromSigner(contract, alice.address).tx.batchTransferFrom(sender.address, alice.address, [[token1, amount1], [token2, amount2]], [])).to.eventually.be.fulfilled
 

--- a/tests/e2e/psp35/psp35.tests.ts
+++ b/tests/e2e/psp35/psp35.tests.ts
@@ -27,7 +27,7 @@ describe('MY_PSP35', () => {
     }
 
     await expect(query.allowance(sender.address, alice.address, token)).to.have.output(0)
-    await expect(tx.approve(alice.address, [token, 10])).to.eventually.be.fulfilled
+    await expect(tx.approve(alice.address, token, 10)).to.eventually.be.fulfilled
     await expect(query.allowance(sender.address, alice.address, token)).to.have.output(10)
   })
 
@@ -104,11 +104,11 @@ describe('MY_PSP35', () => {
     await expect(query.allowance(sender.address, alice.address, token))
       .to.have.output(0)
 
-    await expect(contract.tx.approve(alice.address, [token, tokenAmount])).to.eventually.be.fulfilled
+    await expect(contract.tx.approve(alice.address, token, tokenAmount)).to.eventually.be.fulfilled
     await expect(query.allowance(sender.address, alice.address, token))
       .to.have.output(tokenAmount)
 
-    await expect(contract.tx.approve(alice.address, null)).to.eventually.be.fulfilled
+    await expect(contract.tx.approve(alice.address, null, '340282366920938463463374607431768211455')).to.eventually.be.fulfilled
     await expect(query.allowance(sender.address, alice.address, token))
       .to.have.output('340282366920938463463374607431768211455')
   })
@@ -157,7 +157,7 @@ describe('MY_PSP35', () => {
     await expect(tx.mintTokens(token1, token1Amount)).to.eventually.be.fulfilled
     await expect(tx.mintTokens(token2, token2Amount)).to.eventually.be.fulfilled
 
-    await expect(fromSigner(contract, alice.address).tx.approve(sender.address, null)).to.eventually.be.fulfilled
+    await expect(fromSigner(contract, alice.address).tx.approve(sender.address, null, '340282366920938463463374607431768211455')).to.eventually.be.fulfilled
     await expect(contract.tx.transferFrom(sender.address, alice.address, token2, token2Amount, [])).to.eventually.be.fulfilled
 
     await expect(query.balanceOf(sender.address, token1)).to.have.output(token1Amount)
@@ -184,7 +184,7 @@ describe('MY_PSP35', () => {
     await expect(tx.mintTokens(token, tokenAmount)).to.eventually.be.fulfilled
 
     await expect(query.balanceOf(sender.address, token)).to.have.output(tokenAmount)
-    await fromSigner(contract, alice.address).tx.approve(sender.address, [token, tokenAmount])
+    await fromSigner(contract, alice.address).tx.approve(sender.address, token, tokenAmount)
 
     await expect(contract.tx.transferFrom(sender.address, alice.address, token, tokenAmount + 1, []))
       .to.eventually.be.rejected

--- a/tests/e2e/psp35/psp35.tests.ts
+++ b/tests/e2e/psp35/psp35.tests.ts
@@ -108,7 +108,7 @@ describe('MY_PSP35', () => {
     await expect(query.allowance(sender.address, alice.address, token))
       .to.have.output(tokenAmount)
 
-    await expect(contract.tx.approve(alice.address, null, '340282366920938463463374607431768211455')).to.eventually.be.fulfilled
+    await expect(contract.tx.approve(alice.address, null, 1)).to.eventually.be.fulfilled
     await expect(query.allowance(sender.address, alice.address, token))
       .to.have.output('340282366920938463463374607431768211455')
   })
@@ -157,7 +157,7 @@ describe('MY_PSP35', () => {
     await expect(tx.mintTokens(token1, token1Amount)).to.eventually.be.fulfilled
     await expect(tx.mintTokens(token2, token2Amount)).to.eventually.be.fulfilled
 
-    await expect(fromSigner(contract, alice.address).tx.approve(sender.address, null, '340282366920938463463374607431768211455')).to.eventually.be.fulfilled
+    await expect(fromSigner(contract, alice.address).tx.approve(sender.address, null, 1)).to.eventually.be.fulfilled
     await expect(contract.tx.transferFrom(sender.address, alice.address, token2, token2Amount, [])).to.eventually.be.fulfilled
 
     await expect(query.balanceOf(sender.address, token1)).to.have.output(token1Amount)

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -56,11 +56,12 @@ mod proxy {
     }
 
     impl OwnableStorage for MyProxy {
-        fn get(&self) -> &OwnableData {
+        type Data = OwnableData;
+        fn get(&self) -> &Self::Data {
             &self.proxy.ownable
         }
 
-        fn get_mut(&mut self) -> &mut OwnableData {
+        fn get_mut(&mut self) -> &mut Self::Data {
             &mut self.proxy.ownable
         }
     }

--- a/tests/psp34_enumerable.rs
+++ b/tests/psp34_enumerable.rs
@@ -114,6 +114,7 @@ mod psp34_enumerable {
         assert!(nft._mint_to(accounts.alice, Id::U8(2u8)).is_ok());
         // check Alice token by index
         assert_eq!(nft.owners_token_by_index(accounts.alice, 0u128), Ok(Id::U8(1u8)));
+        assert_eq!(nft.owners_token_by_index(accounts.alice, 1u128), Ok(Id::U8(2u8)));
         // act. transfer token from alice to bob
         assert!(nft.transfer(accounts.bob, Id::U8(1u8), vec![]).is_ok());
         // bob owns token

--- a/tests/psp34_enumerable.rs
+++ b/tests/psp34_enumerable.rs
@@ -40,13 +40,11 @@ mod psp34_enumerable {
         },
     };
 
-    #[derive(Default, SpreadAllocate, PSP34Storage, PSP34EnumerableStorage)]
+    #[derive(Default, SpreadAllocate, PSP34Storage)]
     #[ink(storage)]
     pub struct PSP34Struct {
         #[PSP34StorageField]
-        psp34: PSP34Data,
-        #[PSP34EnumerableStorageField]
-        metadata: PSP34EnumerableData,
+        psp34: PSP34Data<EnumerableBalances>,
     }
 
     impl PSP34Internal for PSP34Struct {

--- a/tests/psp35.rs
+++ b/tests/psp35.rs
@@ -225,15 +225,15 @@ mod psp35 {
         // no approvall exists yet
         assert_eq!(nft.allowance(accounts.alice, accounts.bob, None), 0);
         // increase allowance
-        assert!(nft.approve(accounts.bob, Some((token_id.clone(), 1))).is_ok());
+        assert!(nft.approve(accounts.bob, Some(token_id.clone()), 1).is_ok());
         // allowance increased
         assert_eq!(nft.allowance(accounts.alice, accounts.bob, Some(token_id.clone())), 1);
         // decrease allowance
-        assert!(nft.approve(accounts.bob, Some((token_id.clone(), 0))).is_ok());
+        assert!(nft.approve(accounts.bob, Some(token_id.clone()), 0).is_ok());
         // allowance decreased
         assert_eq!(nft.allowance(accounts.alice, accounts.bob, Some(token_id.clone())), 0);
         // approval for all
-        assert!(nft.approve(accounts.bob, None).is_ok());
+        assert!(nft.approve(accounts.bob, None, Balance::MAX).is_ok());
         // approval for all exists
         assert_eq!(nft.allowance(accounts.alice, accounts.bob, None), Balance::MAX);
         // approval for token exists
@@ -331,7 +331,7 @@ mod psp35 {
         // Create a new contract instance.
         let mut nft = PSP35Struct::new();
         assert!(nft.mint(accounts.alice, token_id.clone(), mint_amount).is_ok());
-        assert!(nft.approve(accounts.bob, Some((token_id.clone(), mint_amount))).is_ok());
+        assert!(nft.approve(accounts.bob, Some(token_id.clone()), mint_amount).is_ok());
 
         change_caller(accounts.bob);
         assert!(nft

--- a/tests/psp35_batch.rs
+++ b/tests/psp35_batch.rs
@@ -248,7 +248,7 @@ mod psp35_batch {
         // Create a new contract instance.
         let mut nft = PSP35Struct::new();
         assert!(nft.mint(accounts.alice, ids_amounts.clone()).is_ok());
-        assert!(nft.approve(accounts.bob, None).is_ok());
+        assert!(nft.approve(accounts.bob, None, Balance::MAX).is_ok());
 
         change_caller(accounts.bob);
         assert!(nft


### PR DESCRIPTION
Soon we will have 3 enumerable extensions. All of them use the same pattern, to reuse the code added a new `MultipleValueMapping`(Maybe we need better naming=) ).

Also to have the optimal implementation in the OpenBrush implemented its own `Mapping` that allows unifying the API calls and use the only one type during the interaction with it. It helps reduce the size of the contract and improve performance because we can pass references everywhere(Only `PSP35` is rewritten as a test. It reduced the size of the contract by 600 bytes. Updated other implementations in follow-up PR).

Refactored data storage traits to support generics. It is the preparation before big refactoring.