### PR TITLE
[WIP] reference impl of mocked corss-contract calls in ink unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ pausable = ["openbrush_contracts/pausable"]
 timelock_controller = ["openbrush_contracts/timelock_controller"]
 proxy = ["openbrush_contracts/proxy"]
 diamond = ["openbrush_contracts/diamond"]
+mockable = ["openbrush_lang/mockable"]
 
 [profile.release]
 panic = "abort"

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -44,3 +44,4 @@ std = [
     "scale/std",
     "scale-info/std",
 ]
+mockable = []

--- a/lang/codegen/src/trait_definition.rs
+++ b/lang/codegen/src/trait_definition.rs
@@ -49,8 +49,6 @@ pub fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
     }
     let attrs: proc_macro2::TokenStream = _attrs.into();
     let (mock_type, attrs) = extract_mock_config(attrs);
-    println!("mock_type: {:?}", mock_type);
-    println!("extracted_attrs: {:?}", attrs);
     let mut trait_item: ItemTrait = parse2(_input).unwrap();
     let trait_without_ink_attrs;
     let ink_code;
@@ -139,7 +137,6 @@ pub fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
 
         #maybe_use_mock_env
     };
-    // println!("Final output: {}", code);
     code.into()
 }
 

--- a/lang/codegen/src/trait_definition.rs
+++ b/lang/codegen/src/trait_definition.rs
@@ -120,7 +120,7 @@ pub fn generate(_attrs: TokenStream, _input: TokenStream) -> TokenStream {
 
         let pub_mock_env_ident = format_ident!("mock_{}", trait_item.ident.to_string().to_lowercase());
         maybe_use_mock_env = quote! {
-            #[cfg(test)]
+            #[cfg(any(test, feature = "mockable"))]
             pub mod #pub_mock_env_ident {
                 pub use super :: #namespace_ident :: { mock_env as env , using , deploy };
             }
@@ -270,11 +270,14 @@ fn generate_wrapper(ink_trait: ItemTrait, mock_type: Option<TokenStream>) -> pro
 
             let message_test_impl = match &mock_type {
                 Some(_mock_ty) => quote! {
-                    mock_env :: with(|registry| {
-                        let mut mock_ref = registry.get_mut(self).expect("not an address of mocked contract");
-                        mock_ref.borrow_mut(). #message_ident (
+                    mock_env :: with(|ctx| {
+                        let mut mock_ref = ctx.register.get_mut(self).expect("not an address of mocked contract");
+                        ctx.stack.borrow_mut().push(&self);
+                        let result = mock_ref.borrow_mut(). #message_ident (
                             #( #input_bindings , )*
-                        )
+                        );
+                        ctx.stack.borrow_mut().pop();
+                        result
                     }).expect("mock object not set")
                 },
                 None => quote! { ::core::panic!("cross-contract call is not supported in ink tests; try to set a mock object?") }
@@ -286,13 +289,13 @@ fn generate_wrapper(ink_trait: ItemTrait, mock_type: Option<TokenStream>) -> pro
                     & self
                     #( , #input_bindings : #input_types )*
                 ) -> #output_ty {
-                    #[cfg(not(test))]
+                    #[cfg(not(any(test, feature = "mockable")))]
                     {
                         Self::#message_builder_ident(self #( , #input_bindings)*)
                             .fire()
                             .unwrap_or_else(|err| ::core::panic!("{}: {:?}", #panic_str, err))
                     }
-                    #[cfg(test)]
+                    #[cfg(any(test, feature = "mockable"))]
                     {
                         #message_test_impl
                     }
@@ -328,40 +331,60 @@ fn generate_wrapper(ink_trait: ItemTrait, mock_type: Option<TokenStream>) -> pro
     let def_messages = def_messages.iter();
 
     let maybe_mock_environmental = match mock_type {
-        Some(ty) =>{
+        Some(ty) => {
             quote! {
-                #[cfg(test)]
-                ::environmental::environmental!(
-                    pub mock_env : std::collections::BTreeMap<
+                #[cfg(any(test, feature = "mockable"))]
+                pub struct Context {
+                    pub stack: std::rc::Rc<std::cell::RefCell<
+                        ::openbrush::traits::mock::ManagedCallStack
+                    >>,
+                    pub register: std::collections::BTreeMap<
                         ::openbrush::traits::AccountId,
                         std::rc::Rc<std::cell::RefCell< #ty >>
-                    > 
+                    >
+                }
+
+                #[cfg(any(test, feature = "mockable"))]
+                ::environmental::environmental!(
+                    pub mock_env : Context
                 );
 
-                #[cfg(test)]
-                pub fn using<F: FnOnce()>(f: F) {
-                    let mut env = Default::default();
+                #[cfg(any(test, feature = "mockable"))]
+                pub fn using<F: FnOnce()>(
+                    stack: std::rc::Rc<std::cell::RefCell<::openbrush::traits::mock::ManagedCallStack>>,
+                    f: F
+                ) {
+                    let mut env = Context {
+                        stack,
+                        register: Default::default()
+                    };
                     mock_env::using(&mut env, f);
                 }
 
-                #[cfg(test)]
-                pub fn deploy(inner_contract : #ty) -> (::openbrush::traits::AccountId, std::rc::Rc<std::cell::RefCell< #ty >>) {
+                #[cfg(any(test, feature = "mockable"))]
+                pub fn deploy(inner_contract : #ty) -> (::openbrush::traits::mock::Addressable< #ty >) {
                     let contract: std::rc::Rc<std::cell::RefCell< #ty >> = std::rc::Rc::new(
                         std::cell::RefCell::< #ty >::new(inner_contract)
                     );
-                    mock_env::with(|register| {
-                        let n: u8 = register.len().try_into()
+                    let (account_id, contract, stack) = mock_env::with(|ctx| {
+                        let n: u8 = ctx.register.len().try_into()
                             .expect("too many contracts to fit into u8");
                         let mut pat = [ #( #mock_address_pattern,  )* ];
                         pat[31] = n;
                         let account_id: ::openbrush::traits::AccountId = pat.into();
 
-                        register.insert(account_id.clone(), contract.clone());
-                        (account_id, contract)
-                    }).expect("must call within `using()`")
+                        ctx.register.insert(account_id.clone(), contract.clone());
+                        (account_id, contract, ctx.stack.clone())
+                    }).expect("must call within `using()`");
+
+                    ::openbrush::traits::mock::Addressable::new(
+                        account_id,
+                        contract,
+                        stack,
+                    )
                 }
             }
-        },
+        }
         None => quote! {},
     };
 
@@ -411,17 +434,13 @@ fn remove_ink_attrs(mut trait_item: ItemTrait) -> ItemTrait {
 }
 
 /// Extracts the mocking related macro args out from the input
-/// 
+///
 /// Return a tuple of an optional mock target and the args without the mock target
 fn extract_mock_config(attr: TokenStream) -> (Option<TokenStream>, TokenStream) {
     let attr_args = syn::parse2::<attr_args::AttributeArgs>(attr).expect("unable to parse trait_definition attribute");
 
-    let (mock_args, ink_args): (Vec<_>, Vec<_>) = attr_args
-        .into_iter()
-        .partition(|arg| {
-            arg.name.is_ident("mock")
-        });
-    
+    let (mock_args, ink_args): (Vec<_>, Vec<_>) = attr_args.into_iter().partition(|arg| arg.name.is_ident("mock"));
+
     let mock_type = mock_args.first().map(|mock_attr| {
         let ty = &mock_attr.value;
         quote! { #ty }
@@ -452,18 +471,18 @@ mod tests {
                 mock = MyMockType,
                 namespace = ::name::space
             },
-            quote!{
+            quote! {
                 pub trait SubmittableOracle {
                     #[ink(message)]
                     fn admin(&self) -> AccountId;
-            
+
                     #[ink(message)]
                     fn verifier(&self) -> Verifier;
-            
+
                     #[ink(message)]
                     fn attest(&self, arg: String) -> Result<Attestation, ()>;
                 }
-            }
+            },
         );
 
         println!("OUTPUT:\n\n{:}", r);

--- a/lang/codegen/src/trait_definition.rs
+++ b/lang/codegen/src/trait_definition.rs
@@ -272,11 +272,11 @@ fn generate_wrapper(ink_trait: ItemTrait, mock_type: Option<TokenStream>) -> pro
                 Some(_mock_ty) => quote! {
                     mock_env :: with(|ctx| {
                         let mut mock_ref = ctx.register.get_mut(self).expect("not an address of mocked contract");
-                        ctx.stack.borrow_mut().push(&self);
+                        ctx.stack.push(&self);
                         let result = mock_ref.borrow_mut(). #message_ident (
                             #( #input_bindings , )*
                         );
-                        ctx.stack.borrow_mut().pop();
+                        ctx.stack.pop();
                         result
                     }).expect("mock object not set")
                 },
@@ -335,9 +335,7 @@ fn generate_wrapper(ink_trait: ItemTrait, mock_type: Option<TokenStream>) -> pro
             quote! {
                 #[cfg(any(test, feature = "mockable"))]
                 pub struct Context {
-                    pub stack: std::rc::Rc<std::cell::RefCell<
-                        ::openbrush::traits::mock::ManagedCallStack
-                    >>,
+                    pub stack: ::openbrush::traits::mock::SharedCallStack,
                     pub register: std::collections::BTreeMap<
                         ::openbrush::traits::AccountId,
                         std::rc::Rc<std::cell::RefCell< #ty >>
@@ -351,7 +349,7 @@ fn generate_wrapper(ink_trait: ItemTrait, mock_type: Option<TokenStream>) -> pro
 
                 #[cfg(any(test, feature = "mockable"))]
                 pub fn using<F: FnOnce()>(
-                    stack: std::rc::Rc<std::cell::RefCell<::openbrush::traits::mock::ManagedCallStack>>,
+                    stack: ::openbrush::traits::mock::SharedCallStack,
                     f: F
                 ) {
                     let mut env = Context {

--- a/lang/codegen/src/trait_definition/attr_args.rs
+++ b/lang/codegen/src/trait_definition/attr_args.rs
@@ -1,0 +1,307 @@
+// Taken from ink_lang::ast::attr_args
+
+// Copyright 2018-2021 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use proc_macro2::{
+    Ident,
+    TokenStream as TokenStream2,
+};
+use quote::ToTokens;
+use syn::{
+    ext::IdentExt as _,
+    parse::{
+        Parse,
+        ParseStream,
+    },
+    punctuated::Punctuated,
+    spanned::Spanned,
+    Token,
+};
+
+/// The attribute arguments for the configuration of an ink! smart contract.
+///
+/// These are the segments `env = ::my::env::Environment` and `compile_as_dependency = true`
+/// in `#[ink::contract(env = ::my::env::Environment, compile_as_dependency = true`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct AttributeArgs {
+    args: Punctuated<MetaNameValue, Token![,]>,
+}
+
+/// A name-value pair within an attribute, like `feature = "nightly"`.
+///
+/// The only difference from `syn::MetaNameValue` is that this additionally
+/// allows the `value` to be a plain identifier or path.
+#[derive(Debug, PartialEq, Eq)]
+pub struct MetaNameValue {
+    pub name: syn::Path,
+    pub eq_token: syn::token::Eq,
+    pub value: PathOrLit,
+}
+
+/// Either a path or a literal.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PathOrLit {
+    Path(syn::Path),
+    Lit(syn::Lit),
+}
+
+impl IntoIterator for AttributeArgs {
+    type Item = MetaNameValue;
+    type IntoIter = syn::punctuated::IntoIter<MetaNameValue>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.args.into_iter()
+    }
+}
+
+impl Parse for AttributeArgs {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        Ok(Self {
+            args: Punctuated::parse_terminated(input)?,
+        })
+    }
+}
+
+impl Parse for MetaNameValue {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        let path = input.call(Self::parse_meta_path)?;
+        Self::parse_meta_name_value_after_path(path, input)
+    }
+}
+
+impl ToTokens for PathOrLit {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        match self {
+            Self::Lit(lit) => lit.to_tokens(tokens),
+            Self::Path(path) => path.to_tokens(tokens),
+        }
+    }
+}
+
+impl ToTokens for MetaNameValue {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        self.name.to_tokens(tokens);
+        self.eq_token.to_tokens(tokens);
+        self.value.to_tokens(tokens);
+    }
+}
+
+impl MetaNameValue {
+    /// Like [`syn::Path::parse_mod_style`] but accepts keywords in the path.
+    ///
+    /// # Note
+    ///
+    /// This code was taken from the `syn` implementation for a very similar
+    /// syntactical pattern.
+    fn parse_meta_path(input: ParseStream) -> Result<syn::Path, syn::Error> {
+        Ok(syn::Path {
+            leading_colon: input.parse()?,
+            segments: {
+                let mut segments = Punctuated::new();
+                while input.peek(Ident::peek_any) {
+                    let ident = Ident::parse_any(input)?;
+                    segments.push_value(syn::PathSegment::from(ident));
+                    if !input.peek(syn::Token![::]) {
+                        break
+                    }
+                    let punct = input.parse()?;
+                    segments.push_punct(punct);
+                }
+                if segments.is_empty() {
+                    return Err(input.error("expected path"))
+                } else if segments.trailing_punct() {
+                    return Err(input.error("expected path segment"))
+                }
+                segments
+            },
+        })
+    }
+
+    fn parse_meta_name_value_after_path(
+        name: syn::Path,
+        input: ParseStream,
+    ) -> Result<MetaNameValue, syn::Error> {
+        let span = name.span();
+        Ok(MetaNameValue {
+            name,
+            eq_token: input.parse().map_err(|_error| {
+                syn::Error::new(
+                    <_ as ::syn::spanned::Spanned>::span(&span),
+                    "ink! config options require an argument separated by '='",
+                )
+            })?,
+            value: input.parse()?,
+        })
+    }
+}
+
+impl Parse for PathOrLit {
+    fn parse(input: ParseStream) -> Result<Self, syn::Error> {
+        if input.fork().peek(syn::Lit) {
+            return input.parse::<syn::Lit>().map(PathOrLit::Lit)
+        }
+        if input.fork().peek(Ident::peek_any) || input.fork().peek(Token![::]) {
+            return input.parse::<syn::Path>().map(PathOrLit::Path)
+        }
+        Err(input.error("cannot parse into either literal or path"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    impl AttributeArgs {
+        /// Creates a new attribute argument list from the given arguments.
+        pub fn new<I>(args: I) -> Self
+        where
+            I: IntoIterator<Item = MetaNameValue>,
+        {
+            Self {
+                args: args.into_iter().collect(),
+            }
+        }
+    }
+
+    #[test]
+    fn empty_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! {}).unwrap(),
+            AttributeArgs::new(vec![])
+        )
+    }
+
+    #[test]
+    fn literal_bool_value_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! { name = true }).unwrap(),
+            AttributeArgs::new(vec![MetaNameValue {
+                name: syn::parse_quote! { name },
+                eq_token: syn::parse_quote! { = },
+                value: PathOrLit::Lit(syn::parse_quote! { true }),
+            }])
+        )
+    }
+
+    #[test]
+    fn literal_str_value_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! { name = "string literal" }).unwrap(),
+            AttributeArgs::new(vec![MetaNameValue {
+                name: syn::parse_quote! { name },
+                eq_token: syn::parse_quote! { = },
+                value: PathOrLit::Lit(syn::parse_quote! { "string literal" }),
+            }])
+        )
+    }
+
+    #[test]
+    fn ident_value_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! { name = MyIdentifier }).unwrap(),
+            AttributeArgs::new(vec![MetaNameValue {
+                name: syn::parse_quote! { name },
+                eq_token: syn::parse_quote! { = },
+                value: PathOrLit::Path(syn::parse_quote! { MyIdentifier }),
+            }])
+        )
+    }
+
+    #[test]
+    fn root_path_value_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! { name = ::this::is::my::Path }).unwrap(),
+            AttributeArgs::new(vec![MetaNameValue {
+                name: syn::parse_quote! { name },
+                eq_token: syn::parse_quote! { = },
+                value: PathOrLit::Path(syn::parse_quote! { ::this::is::my::Path }),
+            }])
+        )
+    }
+
+    #[test]
+    fn relative_path_value_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! { name = this::is::my::relative::Path })
+                .unwrap(),
+            AttributeArgs::new(vec![MetaNameValue {
+                name: syn::parse_quote! { name },
+                eq_token: syn::parse_quote! { = },
+                value: PathOrLit::Path(
+                    syn::parse_quote! { this::is::my::relative::Path }
+                ),
+            }])
+        )
+    }
+
+    #[test]
+    fn trailing_comma_works() {
+        let mut expected_args = Punctuated::new();
+        expected_args.push_value(MetaNameValue {
+            name: syn::parse_quote! { name },
+            eq_token: syn::parse_quote! { = },
+            value: PathOrLit::Path(syn::parse_quote! { value }),
+        });
+        expected_args.push_punct(<Token![,]>::default());
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! { name = value, }).unwrap(),
+            AttributeArgs {
+                args: expected_args,
+            }
+        )
+    }
+
+    #[test]
+    fn many_mixed_works() {
+        assert_eq!(
+            syn::parse2::<AttributeArgs>(quote! {
+                name1 = ::root::Path,
+                name2 = false,
+                name3 = "string literal",
+                name4 = 42,
+                name5 = 7.7
+            })
+            .unwrap(),
+            AttributeArgs::new(vec![
+                MetaNameValue {
+                    name: syn::parse_quote! { name1 },
+                    eq_token: syn::parse_quote! { = },
+                    value: PathOrLit::Path(syn::parse_quote! { ::root::Path }),
+                },
+                MetaNameValue {
+                    name: syn::parse_quote! { name2 },
+                    eq_token: syn::parse_quote! { = },
+                    value: PathOrLit::Lit(syn::parse_quote! { false }),
+                },
+                MetaNameValue {
+                    name: syn::parse_quote! { name3 },
+                    eq_token: syn::parse_quote! { = },
+                    value: PathOrLit::Lit(syn::parse_quote! { "string literal" }),
+                },
+                MetaNameValue {
+                    name: syn::parse_quote! { name4 },
+                    eq_token: syn::parse_quote! { = },
+                    value: PathOrLit::Lit(syn::parse_quote! { 42 }),
+                },
+                MetaNameValue {
+                    name: syn::parse_quote! { name5 },
+                    eq_token: syn::parse_quote! { = },
+                    value: PathOrLit::Lit(syn::parse_quote! { 7.7 }),
+                },
+            ])
+        )
+    }
+}

--- a/lang/src/lib.rs
+++ b/lang/src/lib.rs
@@ -21,6 +21,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 pub mod derive;
 mod macros;
 pub mod storage;

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -79,6 +79,7 @@ pub trait Flush: ::ink_storage::traits::SpreadLayout + InkStorage {
 impl<T: ::ink_storage::traits::SpreadLayout + InkStorage> Flush for T {}
 
 /// Types for managing mock cross-contract calls in unit tests
+#[cfg(feature = "mockable")]
 pub mod mock {
     use super::AccountId;
 

--- a/lang/src/traits.rs
+++ b/lang/src/traits.rs
@@ -77,3 +77,213 @@ pub trait Flush: ::ink_storage::traits::SpreadLayout + InkStorage {
 }
 
 impl<T: ::ink_storage::traits::SpreadLayout + InkStorage> Flush for T {}
+
+/// Types for managing mock cross-contract calls in unit tests
+pub mod mock {
+    use super::AccountId;
+
+    use alloc::{
+        rc::Rc,
+        vec::Vec,
+    };
+    use core::{
+        cell::{
+            Ref,
+            RefCell,
+            RefMut,
+        },
+        ops::{
+            Deref,
+            DerefMut,
+        },
+    };
+
+    /// A frame in the call stack
+    #[derive(Clone, Debug)]
+    pub struct MockCallContext {
+        pub level: u32,
+        pub caller: Option<AccountId>,
+        pub callee: AccountId,
+    }
+
+    /// A managed call stack for mocking cross-contract call in test environment
+    pub struct ManagedCallStack {
+        stack: Vec<MockCallContext>,
+    }
+
+    impl ManagedCallStack {
+        /// Crates a call stack with the default `account`
+        pub fn new(account: AccountId) -> Self {
+            ManagedCallStack {
+                stack: alloc::vec![MockCallContext {
+                    level: 0,
+                    caller: None,
+                    callee: account,
+                }],
+            }
+        }
+
+        /// Creates a call stack with the default `account` and returns a shared reference
+        pub fn create_shared(account: AccountId) -> Rc<RefCell<Self>> {
+            Rc::new(RefCell::new(Self::new(account)))
+        }
+
+        /// Changes the caller account
+        ///
+        /// Only allowed outside any contract call (when the stack is empty).
+        pub fn switch_account(&mut self, account: AccountId) -> Result<(), ()> {
+            if self.stack.len() != 1 {
+                return Err(())
+            }
+            let ctx = self.stack.get_mut(0).ok_or(())?;
+            ctx.callee = account;
+            Ok(())
+        }
+
+        /// Pushes a new call frame
+        pub fn push(&mut self, callee: &AccountId) {
+            let parent_ctx = self.peek().clone();
+            self.stack.push(MockCallContext {
+                level: parent_ctx.level + 1,
+                caller: Some(parent_ctx.callee),
+                callee: callee.clone(),
+            });
+            self.sync_to_ink();
+        }
+
+        /// Pops the call frame and returns the frame
+        pub fn pop(&mut self) -> Option<MockCallContext> {
+            if self.stack.len() > 1 {
+                let ctx = self.stack.pop();
+                self.sync_to_ink();
+                ctx
+            } else {
+                None
+            }
+        }
+
+        /// Peeks the current call frame
+        pub fn peek(&self) -> &MockCallContext {
+            self.stack.last().expect("stack is never empty; qed.")
+        }
+
+        /// Syncs the top call frame to ink testing environment
+        pub fn sync_to_ink(&self) {
+            let ctx = self.peek();
+            if let Some(caller) = ctx.caller {
+                ink_env::test::set_caller::<ink_env::DefaultEnvironment>(caller);
+            }
+            ink_env::test::set_callee::<ink_env::DefaultEnvironment>(ctx.callee);
+        }
+    }
+
+    /// A wrapper of a contract with an address for call stake auto-management
+    #[derive(Clone)]
+    pub struct Addressable<T> {
+        inner: Rc<RefCell<T>>,
+        id: AccountId,
+        stack: Rc<RefCell<ManagedCallStack>>,
+    }
+
+    impl<T> Addressable<T> {
+        /// Wraps a contract reference with id and a shared call stack
+        pub fn new(id: AccountId, inner: Rc<RefCell<T>>, stack: Rc<RefCell<ManagedCallStack>>) -> Self {
+            Addressable { inner, id, stack }
+        }
+
+        /// Wraps a native contract object with a simple id
+        ///
+        /// The account id of the contract will be the `id` with zero-padding.
+        pub fn create_native(id: u8, inner: T, stack: Rc<RefCell<ManagedCallStack>>) -> Self {
+            Addressable {
+                inner: Rc::new(RefCell::new(inner)),
+                id: naive_id(id),
+                stack,
+            }
+        }
+
+        /// Returns the account id of the inner contract
+        pub fn id(&self) -> AccountId {
+            self.id.clone()
+        }
+
+        /// Borrows the contract for _a_ call with the stack auto-managed
+        ///
+        /// Holding the ref for multiple calls or nested call is considered abuse.
+        pub fn call(&self) -> ScopedRef<'_, T> {
+            ScopedRef::new(self.inner.borrow(), &self.id, self.stack.clone())
+        }
+
+        /// Borrows the contract for _a_ mut call with the stack auto-managed
+        ///
+        /// Holding the mut ref for multiple calls or nested call is considered abuse.
+        pub fn call_mut(&self) -> ScopedRefMut<'_, T> {
+            ScopedRefMut::new(self.inner.borrow_mut(), &self.id, self.stack.clone())
+        }
+    }
+
+    /// Push a call stack when the `Ref` in scope
+    pub struct ScopedRef<'b, T: 'b> {
+        inner: Ref<'b, T>,
+        stack: Rc<RefCell<ManagedCallStack>>,
+    }
+
+    impl<'b, T> ScopedRef<'b, T> {
+        fn new(inner: Ref<'b, T>, address: &AccountId, stack: Rc<RefCell<ManagedCallStack>>) -> Self {
+            stack.borrow_mut().push(address);
+            Self { inner, stack }
+        }
+    }
+
+    impl<'b, T> Deref for ScopedRef<'b, T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            self.inner.deref()
+        }
+    }
+
+    impl<'b, T> Drop for ScopedRef<'b, T> {
+        fn drop(&mut self) {
+            self.stack.borrow_mut().pop().expect("pop never fails");
+        }
+    }
+
+    /// Push a call stack when the `RefMut` in scope
+    pub struct ScopedRefMut<'b, T: 'b> {
+        inner: RefMut<'b, T>,
+        stack: Rc<RefCell<ManagedCallStack>>,
+    }
+
+    impl<'b, T> ScopedRefMut<'b, T> {
+        fn new(inner: RefMut<'b, T>, address: &AccountId, stack: Rc<RefCell<ManagedCallStack>>) -> Self {
+            stack.borrow_mut().push(address);
+            Self { inner, stack }
+        }
+    }
+
+    impl<'b, T> Deref for ScopedRefMut<'b, T> {
+        type Target = T;
+        fn deref(&self) -> &T {
+            self.inner.deref()
+        }
+    }
+
+    impl<'b, T> DerefMut for ScopedRefMut<'b, T> {
+        fn deref_mut(&mut self) -> &mut T {
+            self.inner.deref_mut()
+        }
+    }
+
+    impl<'b, T> Drop for ScopedRefMut<'b, T> {
+        fn drop(&mut self) {
+            self.stack.borrow_mut().pop().expect("pop never fails");
+        }
+    }
+
+    /// Generates a naive zero-padding account id with a `u8` number
+    pub fn naive_id(id: u8) -> AccountId {
+        let mut address = [0u8; 32];
+        address[31] = id;
+        address.into()
+    }
+}


### PR DESCRIPTION
This is a reference PR to enable cross-contract call in unit tests. I will try to improve it and finally integrate to openbrush in the future.

## Usage

1. Only call contract via `openbrush::trait_definition`. Calling via ink!'s `ContractRef` or the CallBuiler is not supported.
2. When declaring the `trait_definition`, add a `mock = <your contract>` attribute to the macro:

    ```rust
    #[openbrush::trait_definition(mock = fat_badges::FatBadges)]
    pub trait Issuable {
        #[ink(message)]
        fn issue(&mut self, id: u32, dest: AccountId) -> fat_badges::Result<()>;
    }
    #[openbrush::wrapper]
    pub type IssuableRef = dyn Issuable;
    ```

    In this case, `fat_badges::FatBadges` is the real ink contract struct with the message `fn issue(...)` implemented. We defined a trait called `Issuable` because we want to call `fn issue()` in our contract. The mock object must implement all the message you declared in the `trait_definition`. Otherwise the code generated by the macro will not compile.

3. Call the contract ref as usual:

    ```rust
            let badges: &IssuableRef = address;
            badges
                .issue(*id, data.account_id)
                .or(Err(Error::FailedToIssueBadge))
    ```
4. In your unit test, you need to restructure your code as below:

    ```rust
    use crate::issuable::mock_issuable;
    use openbrush::traits::mock::{Addressable, ManagedCallStack};
    
    // 1. Create a call stack (setting Alice as the default caller)
    let stack = ManagedCallStack::create_shared(accounts.alice);
    // 2. Load the stack to the mock module, and only run contract calls inside the lambda
    mock_issuable::using(stack.clone(), || {
        // 3. Deploy a mock contract. It automatically allocate you an address
        let badges = mock_issuable::deploy(fat_badges::FatBadges::new());
    
        // 4. Construct our contract
        let contract = Addressable::create_native(1, EasyOracle::new(), stack);

        // Now you can test your contract as usual. The address in the contract should be handled properly.
    }
    ```

    Note that each `#[openbrush::trait_definition]` will generate a corresponding `mock_<trait-name>` module. If there are more traits, you will need to call nested `using` multiple times. Here `mock_issuable` is generated by `trait Issuable`.

5. Your contracts are either deployed by `mock_<trait-name>::deploy()` or `Addressable::create_native`. In both case you get an `Addressable<T>` object that allows you to call the contract with the call stack managed properly:

    ```rust
    // A mutable call
    badges.call_mut().new_badge("test-badge".to_string())
    // A immutable call
    contract.call().attest_gist("https://gist.githubusercontent.com/...".to_string())
    ```

6. If you define the `#[openbrush::trait_definition]` in a remote crate, you need to enable `feature = mockable` in that crate.

## Full Example

Check `trait Issuable` and `fn end_to_end()`:

- <https://github.com/Phala-Network/oracle-workshop/blob/6a1e4f7ebc349ca6c1eb9e0bf96eafd0079d1168/easy_oracle/lib.rs>

## How it works

ink! doesn't support cross-contract call in unit tests because:

1. It doesn't handle contract address at all. All the contracts are just plain rust objects without any address.
2. It doesn't track the call stack at all. All the function calls are just plain rust call, leaving no room to inject any code to manage the call stack

Therefore the idea is to:

1. Make a contract register to store a map between the contract address and the contract object
2. Inject code to wherever a cross-contract call is being made to properly handle the call stack

It turns out `#[openbrush::trait_definition]` is a perfect place to inject code. It generates the stub functions to do the actual corss-contract calls as you defined. These functions invoke the ink syscall to initiate the cross-contract calls. However, in a unit test, we just want to call the target contract object. To simulate the cross-contract call, we also want the `caller` and `callee` updated properly. This can be easily done via a `#[cfg(test)]` switch.

Another problem is to manage the contract address register and the call states. This is as easy as creating a map from the contract address and the object, and a call stack in the unit test function. However, to make it easily accessible in the contract and the `trait_definition` stub functions, we need to use `environmental` crate. It loads the states to a global variable safely, and allows the access in the very deep functions.

To make everything easy, we have created a few types:

- `Addressable<T>`: A wrapper struct around a contract. It stores the address of the contract, and a reference to the call stack. Whenever you invoke the contract, you will call `a.call()` or `a.call_mut()`, which pushes the contract address to the stack and pop it out in the lifecycle of the returned reference object.
- `ManagedCallStack`: Implements a call stack, and updates the ink! test env (`caller` and `callee`) accordingly

We generate a `mod mock_<trait-name>` for each defined trait and provides the following functions:

- `deploy(contract)`: Deploy a plain contract, allocate an address, and insert it to the register map. Finally it returns you a `Addressable<T>`.
- `using(call_stack, lambda)`: Load a `ManagedCallStack` to the inner global variable in the scope of `lambda`. Only within the `lambda` the cross-contract call are allowed.
