### PR TITLE
Updated ink! to 3.3.0 and OpenBrush to 2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,9 @@ jobs:
             while $has_timeout
             do
               substrate-contracts-node --tmp --dev & P1=$!;
+              set +e;
               output=$(yarn test:mocha-single ./$test || true);
+              set -e;
               if echo $output | grep -q 'For async tests and hooks, ensure "done()" is called'; then
                 echo $output;
                 has_timeout=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
                 has_timeout=true
               else
                 yarn test:mocha-single ./$test
+                has_timeout=false
               fi
               kill $P1;
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,47 @@
 name: CI/CD
+
 on:
   pull_request:
     branches: [ main ]
+
 jobs:
   rustfmt:
+    concurrency:
+      group: rustfmt-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/supercolony-net/openbrush-contracts-ci
-      options: --user root
-      env:
-        CARGO_TARGET_DIR: /usr/local/cache/target
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
       - name: Rustfmt check
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
   unit-test:
+    concurrency:
+      group: unit-test-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/supercolony-net/openbrush-contracts-ci
-      options: --user root
-      env:
-        CARGO_TARGET_DIR: /usr/local/cache/target
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+
       - name: Build & Run cargo tests
         run: |
-          RUSTFLAGS="-D warnings" cargo test --all-features --workspace -- --test-threads=10
+          RUSTFLAGS="-D warnings" cargo +nightly test --all-features --workspace -- --test-threads=10
   examples-builds:
+    concurrency:
+      group: examples-builds-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/supercolony-net/openbrush-contracts-ci
@@ -37,18 +52,57 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Yarn install dependencies
         run: |
           yarn
           yarn add ts-node
+
+      - name: Cache rust artifacts
+        id: cache-rust-artifacts
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/cache/target
+          key: cache-rust-artifacts-${{ hashFiles('Cargo.toml') }}-${{ github.ref }}
+          restore-keys: |
+            cache-rust-artifacts-${{ hashFiles('Cargo.toml') }}
+
+      - name: Cache contract artifacts
+        id: cache-contract-artifacts
+        uses: actions/cache@v3
+        with:
+          path: artifacts
+          key: cache-contract-artifacts-${{ github.sha }}
+
       - name: Redspot Сompile examples
         run: |
           chown -R root .
           chmod -R a+rwx .
-          RUSTFLAGS="-D warnings" yarn build:release
-  integration-tests:
+          yarn build:release
+  caching-artifacts:
+    concurrency:
+      group: caching-artifacts-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
+    needs: examples-builds
+    container:
+      image: ghcr.io/supercolony-net/openbrush-contracts-ci
+      options: --user root
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Copy rust artifacts
+        id: cache-rust-artifacts
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/cache/target
+          key: cache-rust-artifacts-${{ hashFiles('Cargo.toml') }}
+  integration-tests:
+    concurrency:
+      group: integration-tests-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    needs: examples-builds
     container:
       image: ghcr.io/supercolony-net/openbrush-contracts-ci
       options: --user root
@@ -58,20 +112,33 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '16.x'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Yarn install dependencies
         run: |
           yarn
           yarn add ts-node
-      - name: Redspot Сompile
-        run: |
-          chown -R root .
-          chmod -R a+rwx .
-          yarn build:release
+
+      - name: Cache contract artifacts
+        id: cache-contract-artifacts
+        uses: actions/cache@v3
+        with:
+          path: artifacts
+          key: cache-contract-artifacts-${{ github.sha }}
+
       - name: Run Test Mocha
         run: |
           for test in $(find tests -type f -regex ".*\.ts"); do
-            substrate-contracts-node --tmp --dev & P1=$!;
-            yarn test:mocha-single ./$test;
-            kill $P1;
+            has_timeout=true
+            while $has_timeout
+            do
+              substrate-contracts-node --tmp --dev & P1=$!;
+              output=$(yarn test:mocha-single ./$test || true);
+              if echo $output | grep -q 'For async tests and hooks, ensure "done()" is called'; then
+                echo $output;
+                has_timeout=true
+              else
+                yarn test:mocha-single ./$test
+              fi
+              kill $P1;
+            done
           done

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -1,4 +1,4 @@
-name: documentation
+name: Documentation
 
 on:
   pull_request:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 
 [package]
 name = "openbrush"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 
@@ -27,19 +27,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-openbrush_contracts = { version = "~2.0.0", path = "contracts", default-features = false }
-openbrush_lang = { version = "~2.0.0", path = "lang", default-features = false }
+openbrush_contracts = { version = "~2.1.0", path = "contracts", default-features = false }
+openbrush_lang = { version = "~2.1.0", path = "lang", default-features = false }
 
 [lib]
 name = "openbrush"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ std = [
     "openbrush_contracts/std",
     "openbrush_lang/std",
 ]
+access_control = ["openbrush_contracts/access_control"]
 psp22 = ["openbrush_contracts/psp22"]
 psp34 = ["openbrush_contracts/psp34"]
 psp35 = ["openbrush_contracts/psp35"]
 ownable = ["openbrush_contracts/ownable"]
-access_control = ["openbrush_contracts/access_control"]
 payment_splitter = ["openbrush_contracts/payment_splitter"]
 reentrancy_guard = ["openbrush_contracts/reentrancy_guard"]
 pausable = ["openbrush_contracts/pausable"]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_contracts"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -15,19 +15,19 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-derive = { package = "openbrush_contracts_derive", version = "~2.0.0", path = "derive" }
-openbrush = { version = "~2.0.0", package = "openbrush_lang", path = "../lang", default-features = false }
+derive = { package = "openbrush_contracts_derive", version = "~2.1.0", path = "derive" }
+openbrush = { version = "~2.1.0", package = "openbrush_lang", path = "../lang", default-features = false }
 
 [lib]
 name = "openbrush_contracts"

--- a/contracts/derive/Cargo.toml
+++ b/contracts/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_contracts_derive"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "lib.rs"]
 syn = { version = "1.0" }
 quote = "1.0"
 proc-macro2 = "1"
-openbrush = { package = "openbrush_lang", version = "~2.0.0", path = "../../lang" }
+openbrush = { package = "openbrush_lang", version = "~2.1.0", path = "../../lang" }
 
 [lib]
 name = "openbrush_contracts_derive"

--- a/contracts/src/access/access_control/extensions/enumerable.rs
+++ b/contracts/src/access/access_control/extensions/enumerable.rs
@@ -21,7 +21,7 @@
 
 pub use crate::{
     access_control::*,
-    traits::access_control_enumerable::*,
+    traits::access_control::extensions::enumerable::*,
 };
 pub use derive::AccessControlEnumerableStorage;
 use openbrush::{
@@ -77,11 +77,11 @@ impl<T> AccessControlEnumerable for T
 where
     T: AccessControlEnumerableMembersStorage<Data = EnumerableMembers> + AccessControl,
 {
-    default fn get_role_member(&self, role: RoleType, index: u128) -> Option<AccountId> {
-        self.get().role_members.get_value(role, &index)
+    default fn get_role_member(&self, role: RoleType, index: u32) -> Option<AccountId> {
+        self.get().role_members.get_value(role, &(index as u128))
     }
 
-    default fn get_role_member_count(&self, role: RoleType) -> u128 {
-        self.get().role_members.count(role)
+    default fn get_role_member_count(&self, role: RoleType) -> u32 {
+        self.get().role_members.count(role) as u32
     }
 }

--- a/contracts/src/access/access_control/members.rs
+++ b/contracts/src/access/access_control/members.rs
@@ -41,6 +41,7 @@ pub const MEMBERS_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::AccessContro
 #[openbrush::storage(MEMBERS_KEY)]
 pub struct Members {
     pub members: Mapping<(RoleType, AccountId), (), MembersKey>,
+    pub _reserved: Option<()>,
 }
 
 pub struct MembersKey;

--- a/contracts/src/token/psp35/balances.rs
+++ b/contracts/src/token/psp35/balances.rs
@@ -79,9 +79,12 @@ impl BalancesManager for Balances {
     }
 
     fn increase_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, mint: bool) -> Result<(), PSP35Error> {
-        if *amount == 0 {
+        let amount = *amount;
+
+        if amount == 0 {
             return Ok(())
         }
+
         let id = &Some(id);
         let balance_before = self.balance_of(owner, id);
 
@@ -91,11 +94,11 @@ impl BalancesManager for Balances {
         }
 
         self.balances
-            .insert(&(owner, id), &balance_before.checked_add(*amount).unwrap());
+            .insert(&(owner, id), &balance_before.checked_add(amount).unwrap());
 
         if mint {
             let supply_before = self.total_supply(id);
-            self.supply.insert(id, &supply_before.checked_add(*amount).unwrap());
+            self.supply.insert(id, &supply_before.checked_add(amount).unwrap());
 
             if supply_before == 0 {
                 self.supply
@@ -107,13 +110,16 @@ impl BalancesManager for Balances {
     }
 
     fn decrease_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, burn: bool) -> Result<(), PSP35Error> {
-        if *amount == 0 {
+        let amount = *amount;
+
+        if amount == 0 {
             return Ok(())
         }
+
         let id = &Some(id);
         let balance_after = self
             .balance_of(owner, id)
-            .checked_sub(*amount)
+            .checked_sub(amount)
             .ok_or(PSP35Error::InsufficientBalance)?;
         self.balances.insert(&(owner, id), &balance_after);
 
@@ -130,7 +136,7 @@ impl BalancesManager for Balances {
         if burn {
             let supply_after = self
                 .total_supply(id)
-                .checked_sub(*amount)
+                .checked_sub(amount)
                 .ok_or(PSP35Error::InsufficientBalance)?;
             self.supply.insert(id, &supply_after);
 

--- a/contracts/src/token/psp35/balances.rs
+++ b/contracts/src/token/psp35/balances.rs
@@ -79,6 +79,9 @@ impl BalancesManager for Balances {
     }
 
     fn increase_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, mint: bool) -> Result<(), PSP35Error> {
+        if *amount == 0 {
+            return Ok(())
+        }
         let id = &Some(id);
         let balance_before = self.balance_of(owner, id);
 
@@ -104,6 +107,9 @@ impl BalancesManager for Balances {
     }
 
     fn decrease_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, burn: bool) -> Result<(), PSP35Error> {
+        if *amount == 0 {
+            return Ok(())
+        }
         let id = &Some(id);
         let balance_after = self
             .balance_of(owner, id)

--- a/contracts/src/token/psp35/extensions/enumerable.rs
+++ b/contracts/src/token/psp35/extensions/enumerable.rs
@@ -45,7 +45,7 @@ pub const STORAGE_KEY: [u8; 32] = ink_lang::blake2x256!("openbrush::PSP35Enumera
 pub struct EnumerableBalances {
     pub enumerable: MultiMapping<Option<AccountId>, Id, EnumerableKey>,
     pub balances: Mapping<(AccountId, Id), Balance, BalancesKey>,
-    pub total_supply: Mapping<Id, Balance>,
+    pub supply: Mapping<Id, Balance>,
     pub _reserved: Option<()>,
 }
 
@@ -64,26 +64,37 @@ impl<'a> TypeGuard<'a> for BalancesKey {
 declare_storage_trait!(PSP35EnumerableBalancesStorage);
 
 impl BalancesManager for EnumerableBalances {
-    fn balance_of(&self, owner: &AccountId, id: &Id) -> Balance {
-        self.balances.get(&(owner, id)).unwrap_or(0)
+    #[inline(always)]
+    fn balance_of(&self, owner: &AccountId, id: &Option<&Id>) -> Balance {
+        match id {
+            None => self.enumerable.count(&Some(owner)),
+            Some(id) => self.balances.get(&(owner, id)).unwrap_or(0),
+        }
+    }
+
+    #[inline(always)]
+    fn total_supply(&self, id: &Option<&Id>) -> Balance {
+        match id {
+            None => self.enumerable.count(&None),
+            Some(id) => self.supply.get(id).unwrap_or(0),
+        }
     }
 
     fn increase_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, mint: bool) -> Result<(), PSP35Error> {
-        let initial_balance = self.balance_of(owner, id);
+        let balance_before = self.balance_of(owner, &Some(id));
         self.balances
-            .insert(&(owner, id), &(initial_balance.checked_add(*amount).unwrap()));
+            .insert(&(owner, id), &(balance_before.checked_add(*amount).unwrap()));
 
-        if initial_balance == 0 {
+        if balance_before == 0 {
             self.enumerable.insert(&Some(owner), id);
         }
 
         if mint {
-            let token_supply = self.total_supply.get(id).unwrap_or(0);
+            let supply_before = self.total_supply(&Some(id));
 
-            self.total_supply
-                .insert(id, &(token_supply.checked_add(*amount).unwrap()));
+            self.supply.insert(id, &(supply_before.checked_add(*amount).unwrap()));
 
-            if token_supply == 0 {
+            if supply_before == 0 {
                 self.enumerable.insert(&None, id);
             }
         }
@@ -91,28 +102,24 @@ impl BalancesManager for EnumerableBalances {
     }
 
     fn decrease_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, burn: bool) -> Result<(), PSP35Error> {
-        let initial_balance = self.balance_of(owner, id);
-        self.balances.insert(
-            &(owner, id),
-            &(initial_balance
-                .checked_sub(*amount)
-                .ok_or(PSP35Error::InsufficientBalance)?),
-        );
+        let balance_after = self
+            .balance_of(owner, &Some(id))
+            .checked_sub(*amount)
+            .ok_or(PSP35Error::InsufficientBalance)?;
+        self.balances.insert(&(owner, id), &balance_after);
 
-        if initial_balance == *amount {
+        if balance_after == 0 {
             self.enumerable.remove_value(&Some(owner), id);
         }
 
         if burn {
-            let token_supply = self.total_supply.get(id).unwrap_or(0);
-            self.total_supply.insert(
-                id,
-                &(token_supply
-                    .checked_sub(*amount)
-                    .ok_or(PSP35Error::InsufficientBalance)?),
-            );
+            let supply_after = self
+                .total_supply(&Some(id))
+                .checked_sub(*amount)
+                .ok_or(PSP35Error::InsufficientBalance)?;
+            self.supply.insert(id, &supply_after);
 
-            if token_supply == *amount {
+            if supply_after == 0 {
                 self.enumerable.remove_value(&None, id);
             }
         }

--- a/contracts/src/token/psp35/extensions/enumerable.rs
+++ b/contracts/src/token/psp35/extensions/enumerable.rs
@@ -81,9 +81,15 @@ impl BalancesManager for EnumerableBalances {
     }
 
     fn increase_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, mint: bool) -> Result<(), PSP35Error> {
+        let amount = *amount;
+
+        if amount == 0 {
+            return Ok(())
+        }
+
         let balance_before = self.balance_of(owner, &Some(id));
         self.balances
-            .insert(&(owner, id), &(balance_before.checked_add(*amount).unwrap()));
+            .insert(&(owner, id), &(balance_before.checked_add(amount).unwrap()));
 
         if balance_before == 0 {
             self.enumerable.insert(&Some(owner), id);
@@ -92,7 +98,7 @@ impl BalancesManager for EnumerableBalances {
         if mint {
             let supply_before = self.total_supply(&Some(id));
 
-            self.supply.insert(id, &(supply_before.checked_add(*amount).unwrap()));
+            self.supply.insert(id, &(supply_before.checked_add(amount).unwrap()));
 
             if supply_before == 0 {
                 self.enumerable.insert(&None, id);
@@ -102,9 +108,15 @@ impl BalancesManager for EnumerableBalances {
     }
 
     fn decrease_balance(&mut self, owner: &AccountId, id: &Id, amount: &Balance, burn: bool) -> Result<(), PSP35Error> {
+        let amount = *amount;
+
+        if amount == 0 {
+            return Ok(())
+        }
+
         let balance_after = self
             .balance_of(owner, &Some(id))
-            .checked_sub(*amount)
+            .checked_sub(amount)
             .ok_or(PSP35Error::InsufficientBalance)?;
         self.balances.insert(&(owner, id), &balance_after);
 
@@ -115,7 +127,7 @@ impl BalancesManager for EnumerableBalances {
         if burn {
             let supply_after = self
                 .total_supply(&Some(id))
-                .checked_sub(*amount)
+                .checked_sub(amount)
                 .ok_or(PSP35Error::InsufficientBalance)?;
             self.supply.insert(id, &supply_after);
 

--- a/contracts/src/token/psp35/psp35.rs
+++ b/contracts/src/token/psp35/psp35.rs
@@ -71,8 +71,12 @@ where
     B: BalancesManager,
     T: PSP35Storage<Data = PSP35Data<B>> + Flush,
 {
-    default fn balance_of(&self, owner: AccountId, id: Id) -> Balance {
-        self.get().balances.balance_of(&owner, &id)
+    default fn balance_of(&self, owner: AccountId, id: Option<Id>) -> Balance {
+        self.get().balances.balance_of(&owner, &id.as_ref())
+    }
+
+    default fn total_supply(&self, id: Option<Id>) -> Balance {
+        self.get().balances.total_supply(&id.as_ref())
     }
 
     default fn allowance(&self, owner: AccountId, operator: AccountId, id: Option<Id>) -> Balance {

--- a/contracts/src/traits/access_control/access_control.rs
+++ b/contracts/src/traits/access_control/access_control.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2012-2022 Supercolony
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the"Software"),
+// to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+pub use crate::traits::errors::AccessControlError;
+use openbrush::traits::AccountId;
+
+pub type RoleType = u32;
+
+#[openbrush::wrapper]
+pub type AccessControlRef = dyn AccessControl;
+
+/// Contract module that allows children to implement role-based access
+/// control mechanisms. This is a lightweight version that doesn't allow enumerating role
+/// members except through off-chain means by accessing the contract event logs.
+///
+/// Roles can be granted and revoked dynamically via the `grant_role` and
+/// `revoke_role`. functions. Each role has an associated admin role, and only
+/// accounts that have a role's admin role can call `grant_role` and `revoke_role`.
+#[openbrush::trait_definition]
+pub trait AccessControl {
+    /// Returns `true` if `account` has been granted `role`.
+    #[ink(message)]
+    fn has_role(&self, role: RoleType, address: AccountId) -> bool;
+
+    /// Returns the admin role that controls `role`. See `grant_role` and `revoke_role`.
+    #[ink(message)]
+    fn get_role_admin(&self, role: RoleType) -> RoleType;
+
+    /// Grants `role` to `account`.
+    ///
+    /// On success a `RoleGranted` event is emitted.
+    ///
+    /// # Errors
+    ///
+    /// Returns with `MissingRole` error if caller can't grant the role.
+    /// Returns with `RoleRedundant` error `account` has `role`.
+    #[ink(message)]
+    fn grant_role(&mut self, role: RoleType, account: AccountId) -> Result<(), AccessControlError>;
+
+    /// Revokes `role` from `account`.
+    ///
+    /// On success a `RoleRevoked` event is emitted.
+    ///
+    /// # Errors
+    ///
+    /// Returns with `MissingRole` error if caller can't grant the `role` or if `account` doesn't have `role`.
+    #[ink(message)]
+    fn revoke_role(&mut self, role: RoleType, account: AccountId) -> Result<(), AccessControlError>;
+
+    /// Revokes `role` from the calling account.
+    /// Roles are often managed via `grant_role` and `revoke_role`: this function's
+    /// purpose is to provide a mechanism for accounts to lose their privileges
+    /// if they are compromised (such as when a trusted device is misplaced).
+    ///
+    /// On success a `RoleRevoked` event is emitted.
+    ///
+    /// # Errors
+    ///
+    /// Returns with `InvalidCaller` error if caller is not `account`.
+    /// Returns with `MissingRole` error if `account` doesn't have `role`.
+    #[ink(message)]
+    fn renounce_role(&mut self, role: RoleType, account: AccountId) -> Result<(), AccessControlError>;
+}

--- a/contracts/src/traits/access_control/extensions/enumerable.rs
+++ b/contracts/src/traits/access_control/extensions/enumerable.rs
@@ -19,7 +19,7 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pub use crate::traits::access_control::RoleType;
+pub use crate::traits::access_control::*;
 use openbrush::traits::AccountId;
 
 #[openbrush::wrapper]
@@ -33,11 +33,11 @@ pub trait AccessControlEnumerable {
     /// Role bearers are not sorted in any particular way, and their
     /// ordering may change at any point.
     #[ink(message)]
-    fn get_role_member(&self, role: RoleType, index: u128) -> Option<AccountId>;
+    fn get_role_member(&self, role: RoleType, index: u32) -> Option<AccountId>;
 
     /// Returns the number of accounts that have `role`.
     /// Can be used together with {get_role_member} to enumerate
     /// all bearers of a role.
     #[ink(message)]
-    fn get_role_member_count(&self, role: RoleType) -> u128;
+    fn get_role_member_count(&self, role: RoleType) -> u32;
 }

--- a/contracts/src/traits/access_control/mod.rs
+++ b/contracts/src/traits/access_control/mod.rs
@@ -19,63 +19,10 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-pub use crate::traits::errors::AccessControlError;
-use openbrush::traits::AccountId;
+mod access_control;
 
-pub type RoleType = u32;
+pub use access_control::*;
 
-#[openbrush::wrapper]
-pub type AccessControlRef = dyn AccessControl;
-
-/// Contract module that allows children to implement role-based access
-/// control mechanisms. This is a lightweight version that doesn't allow enumerating role
-/// members except through off-chain means by accessing the contract event logs.
-///
-/// Roles can be granted and revoked dynamically via the `grant_role` and
-/// `revoke_role`. functions. Each role has an associated admin role, and only
-/// accounts that have a role's admin role can call `grant_role` and `revoke_role`.
-#[openbrush::trait_definition]
-pub trait AccessControl {
-    /// Returns `true` if `account` has been granted `role`.
-    #[ink(message)]
-    fn has_role(&self, role: RoleType, address: AccountId) -> bool;
-
-    /// Returns the admin role that controls `role`. See `grant_role` and `revoke_role`.
-    #[ink(message)]
-    fn get_role_admin(&self, role: RoleType) -> RoleType;
-
-    /// Grants `role` to `account`.
-    ///
-    /// On success a `RoleGranted` event is emitted.
-    ///
-    /// # Errors
-    ///
-    /// Returns with `MissingRole` error if caller can't grant the role.
-    /// Returns with `RoleRedundant` error `account` has `role`.
-    #[ink(message)]
-    fn grant_role(&mut self, role: RoleType, account: AccountId) -> Result<(), AccessControlError>;
-
-    /// Revokes `role` from `account`.
-    ///
-    /// On success a `RoleRevoked` event is emitted.
-    ///
-    /// # Errors
-    ///
-    /// Returns with `MissingRole` error if caller can't grant the `role` or if `account` doesn't have `role`.
-    #[ink(message)]
-    fn revoke_role(&mut self, role: RoleType, account: AccountId) -> Result<(), AccessControlError>;
-
-    /// Revokes `role` from the calling account.
-    /// Roles are often managed via `grant_role` and `revoke_role`: this function's
-    /// purpose is to provide a mechanism for accounts to lose their privileges
-    /// if they are compromised (such as when a trusted device is misplaced).
-    ///
-    /// On success a `RoleRevoked` event is emitted.
-    ///
-    /// # Errors
-    ///
-    /// Returns with `InvalidCaller` error if caller is not `account`.
-    /// Returns with `MissingRole` error if `account` doesn't have `role`.
-    #[ink(message)]
-    fn renounce_role(&mut self, role: RoleType, account: AccountId) -> Result<(), AccessControlError>;
+pub mod extensions {
+    pub mod enumerable;
 }

--- a/contracts/src/traits/mod.rs
+++ b/contracts/src/traits/mod.rs
@@ -20,7 +20,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 pub mod access_control;
-pub mod access_control_enumerable;
 pub mod diamond;
 pub mod errors;
 pub mod flashloan;

--- a/contracts/src/traits/psp35/psp35.rs
+++ b/contracts/src/traits/psp35/psp35.rs
@@ -41,8 +41,16 @@ pub type PSP35Ref = dyn PSP35;
 #[openbrush::trait_definition]
 pub trait PSP35 {
     /// Returns the amount of tokens of token type `id` owned by `account`.
+    ///
+    /// If `id` is `None` returns the total number of `owner`'s tokens.
     #[ink(message)]
-    fn balance_of(&self, owner: AccountId, id: Id) -> Balance;
+    fn balance_of(&self, owner: AccountId, id: Option<Id>) -> Balance;
+
+    /// Returns the total amount of token type `id` in the supply.
+    ///
+    /// If `id` is `None` returns the total number of tokens.
+    #[ink(message)]
+    fn total_supply(&self, id: Option<Id>) -> Balance;
 
     /// Returns amount of `id` token of `owner` that `operator` can withdraw
     /// If `id` is `None` returns allowance `Balance::MAX` of all tokens of `owner`

--- a/docs/docs/smart-contracts/PSP22/Extensions/capped.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/capped.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/pausable.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 and Pausable via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp22", "pausable"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp22", "pausable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
+++ b/docs/docs/smart-contracts/PSP22/Extensions/wrapper.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
+++ b/docs/docs/smart-contracts/PSP22/Utils/token-timelock.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP22/psp22.md
+++ b/docs/docs/smart-contracts/PSP22/psp22.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP22 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp22"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
+++ b/docs/docs/smart-contracts/PSP34/Extensions/metadata.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP34 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp34"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp34"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP34/psp34.md
+++ b/docs/docs/smart-contracts/PSP34/psp34.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP34 via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp34"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp34"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/PSP35/psp35.md
+++ b/docs/docs/smart-contracts/PSP35/psp35.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of PSP35 via `openbrush` feature.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp35"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp35"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/access-control.md
+++ b/docs/docs/smart-contracts/access-control.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Access Control via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["access_control"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["access_control"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/diamond.md
+++ b/docs/docs/smart-contracts/diamond.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Diamond Standard via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["diamond"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["diamond"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/example/contract.md
+++ b/docs/docs/smart-contracts/example/contract.md
@@ -16,18 +16,18 @@ implementation of `Lending` and `LendingPermissioned` traits defined in the `len
 ```toml
 [package]
 name = "lending_contract"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
@@ -36,7 +36,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 shares_contract = { path = "../shares", default-features = false, features = ["ink-as-dependency"]  }
 loan_contract = { path = "../loan", default-features = false, features = ["ink-as-dependency"]  }
 lending_project = { path = "../..", default-features = false }
-openbrush = { version = "~2.0.0", default-features = false, features = ["psp22", "psp34", "pausable", "access_control"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["psp22", "psp34", "pausable", "access_control"] }
 
 [lib]
 name = "lending_contract"

--- a/docs/docs/smart-contracts/example/data.md
+++ b/docs/docs/smart-contracts/example/data.md
@@ -142,7 +142,7 @@ In the `Cargo.toml` of the derive folder you need to import `openbrush` dependen
 syn = { version = "1.0" }
 quote = "1.0"
 proc-macro2 = "1"
-openbrush = { version = "~2.0.0", default-features = false }
+openbrush = { version = "~2.1.0", default-features = false }
 
 [lib]
 name = "point_derive"

--- a/docs/docs/smart-contracts/overview.md
+++ b/docs/docs/smart-contracts/overview.md
@@ -12,19 +12,19 @@ So you should use the same version of the ink! across your project.
 ```toml
 [dependencies]
 # Import of all ink! crates
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 # Brush dependency
-openbrush = { version = "~2.0.0", default-features = false }
+openbrush = { version = "~2.1.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/docs/docs/smart-contracts/ownable.md
+++ b/docs/docs/smart-contracts/ownable.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Ownable via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["ownable"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["ownable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/pausable.md
+++ b/docs/docs/smart-contracts/pausable.md
@@ -12,7 +12,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Pausable via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["pausable"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["pausable"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/payment-splitter.md
+++ b/docs/docs/smart-contracts/payment-splitter.md
@@ -12,7 +12,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Payment Splitter via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["payment_splitter"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["payment_splitter"] }
 
 # payment-splitter uses dividing inside, so your version of rust can require you to disable check overflow.
 [profile.dev]

--- a/docs/docs/smart-contracts/proxy.md
+++ b/docs/docs/smart-contracts/proxy.md
@@ -11,7 +11,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Proxy via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["proxy"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["proxy"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/docs/smart-contracts/reentrancy-guard.md
+++ b/docs/docs/smart-contracts/reentrancy-guard.md
@@ -20,7 +20,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Reentrancy Guard via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["reentrancy_guard"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["reentrancy_guard"] }
 ```
 
 ### Step 2: Add imports
@@ -174,13 +174,13 @@ To do a cross-contract call to `MyFlipper` you need to import the `MyFlipper` co
 
 ```toml
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/docs/docs/smart-contracts/timelock-controller.md
+++ b/docs/docs/smart-contracts/timelock-controller.md
@@ -12,7 +12,7 @@ Include `openbrush` as dependency in the cargo file or you can use [default `Car
 After you need to enable default implementation of Timelock Controller via `openbrush` features.
 
 ```toml
-openbrush = { version = "~2.0.0", default-features = false, features = ["timelock_controller"] }
+openbrush = { version = "~2.1.0", default-features = false, features = ["timelock_controller"] }
 ```
 
 ## Step 2: Add imports and enable unstable feature

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbrush",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/example_project_structure/Cargo.toml
+++ b/example_project_structure/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "lending_project"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net, dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/example_project_structure/contracts/lending/Cargo.toml
+++ b/example_project_structure/contracts/lending/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "lending_contract"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/example_project_structure/contracts/loan/Cargo.toml
+++ b/example_project_structure/contracts/loan/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "loan_contract"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/example_project_structure/contracts/shares/Cargo.toml
+++ b/example_project_structure/contracts/shares/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "shares_contract"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/example_project_structure/contracts/stable_coin/Cargo.toml
+++ b/example_project_structure/contracts/stable_coin/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "stable_coin_contract"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/example_project_structure/derive/Cargo.toml
+++ b/example_project_structure/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project_derive"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
@@ -10,7 +10,7 @@ quote = "1.0"
 proc-macro2 = "1"
 
 # In you code you can import `openbrush_derive` with the next line
-#openbrush = { version = "~2.0.0", default-features = false }
+#openbrush = { version = "~2.1.0", default-features = false }
 
 openbrush = { package = "openbrush_lang", path = "../../lang" }
 

--- a/examples/access_control/Cargo.toml
+++ b/examples/access_control/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_access_control"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/access_control_extensions/enumerable/Cargo.toml
+++ b/examples/access_control_extensions/enumerable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_access_control_enumerable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <nameless.endless@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/diamond/Cargo.toml
+++ b/examples/diamond/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_diamond"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/diamond/diamond_caller/Cargo.toml
+++ b/examples/diamond/diamond_caller/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "diamond_caller"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/diamond/psp22_facet_v1/Cargo.toml
+++ b/examples/diamond/psp22_facet_v1/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_facet_v1"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/diamond/psp22_facet_v2/Cargo.toml
+++ b/examples/diamond/psp22_facet_v2/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_facet_v2"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/diamond/psp22_metadata_facet/Cargo.toml
+++ b/examples/diamond/psp22_metadata_facet/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_metadata_facet"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_ownable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_pausable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/payment_splitter/Cargo.toml
+++ b/examples/payment_splitter/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_payment_splitter"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_proxy"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_metadata_upgradeable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/proxy/psp22_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_upgradeable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_upgradeable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22/Cargo.toml
+++ b/examples/psp22/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/burnable/Cargo.toml
+++ b/examples/psp22_extensions/burnable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_burnable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/capped/Cargo.toml
+++ b/examples/psp22_extensions/capped/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_capped"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/flashmint/Cargo.toml
+++ b/examples/psp22_extensions/flashmint/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_flashmint"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/metadata/Cargo.toml
+++ b/examples/psp22_extensions/metadata/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_metadata"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/mintable/Cargo.toml
+++ b/examples/psp22_extensions/mintable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_mintable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/pausable/Cargo.toml
+++ b/examples/psp22_extensions/pausable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_pausable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_extensions/wrapper/Cargo.toml
+++ b/examples/psp22_extensions/wrapper/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_wrapper"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp22_utils/token_timelock/Cargo.toml
+++ b/examples/psp22_utils/token_timelock/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp22_token_timelock"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp34/Cargo.toml
+++ b/examples/psp34/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp34"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp34_extensions/burnable/Cargo.toml
+++ b/examples/psp34_extensions/burnable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp34_burnable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp34_extensions/enumerable/Cargo.toml
+++ b/examples/psp34_extensions/enumerable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp34_enumerable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp34_extensions/metadata/Cargo.toml
+++ b/examples/psp34_extensions/metadata/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp34_metadata"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp34_extensions/mintable/Cargo.toml
+++ b/examples/psp34_extensions/mintable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp34_mintable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp35/Cargo.toml
+++ b/examples/psp35/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp35"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp35_extensions/batch/Cargo.toml
+++ b/examples/psp35_extensions/batch/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp35_batch"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <artem.lech@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp35_extensions/burnable/Cargo.toml
+++ b/examples/psp35_extensions/burnable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp35_burnable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp35_extensions/enumerable/Cargo.toml
+++ b/examples/psp35_extensions/enumerable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp35_enumerable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <artem.lech@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp35_extensions/metadata/Cargo.toml
+++ b/examples/psp35_extensions/metadata/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp35_metadata"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/psp35_extensions/mintable/Cargo.toml
+++ b/examples/psp35_extensions/mintable/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_psp35_mintable"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/reentrancy_guard/Cargo.toml
+++ b/examples/reentrancy_guard/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "flipper"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "flip_on_me"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/reentrancy_guard/contracts/flipper/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flipper/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_flipper_guard"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/examples/timelock_controller/Cargo.toml
+++ b/examples/timelock_controller/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "my_timelock_controller"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -14,13 +14,13 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-openbrush_lang_macro = { version = "~2.0.0", path = "macro", default-features = false }
+openbrush_lang_macro = { version = "~2.1.0", path = "macro", default-features = false }
 
-ink_env = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"] }

--- a/lang/codegen/Cargo.toml
+++ b/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang_codegen"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -24,7 +24,7 @@ cargo_metadata = "0.13.1"
 unwrap = "1.2.1"
 blake2 = "0.9"
 heck = "0.3.1"
-ink_lang_ir = { version = "~3.2.0", default-features = false }
+ink_lang_ir = { version = "~3.3.0", default-features = false }
 synstructure = "0.12"
 
 [lib]

--- a/lang/codegen/src/storage.rs
+++ b/lang/codegen/src/storage.rs
@@ -134,7 +134,7 @@ fn spread_layout_struct_derive(storage_key: &TokenStream, s: &synstructure::Stru
                 let __key_ptr = &mut ::ink_storage::traits::KeyPtr::from(
                     ::ink_primitives::Key::from(#storage_key)
                 );
-                ::ink_env::set_contract_storage::<()>(__key_ptr.key(), &());
+                ::ink_env::set_contract_storage_return_size::<()>(__key_ptr.key(), &());
                 match self { #push_body }
             }
             fn clear_spread(&self, _: &mut ::ink_storage::traits::KeyPtr) {

--- a/lang/macro/Cargo.toml
+++ b/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang_macro"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -14,18 +14,18 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-openbrush_lang_codegen = { version = "~2.0.0", path = "../codegen", default-features = false }
+openbrush_lang_codegen = { version = "~2.1.0", path = "../codegen", default-features = false }
 syn = "1"
 proc-macro2 = "1"
 synstructure = "0.12"
 
 [dev-dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"] }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"] }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"] }

--- a/lang/src/storage/mapping.rs
+++ b/lang/src/storage/mapping.rs
@@ -87,19 +87,19 @@ where
         RawMapping::<TGK::Type, TGV::Type, &Key>::new(&self.offset_key).insert(key, value)
     }
 
-    /// Insert the given `value` to the contract storage.
-    ///
-    /// Returns the size of the pre-existing value at the specified key if any.
-    #[inline]
-    pub fn insert_return_size<'a, 'b>(&mut self, key: TGK::Type, value: &TGV::Type) -> Option<u32>
-    where
-        TGK: TypeGuard<'a>,
-        TGV: TypeGuard<'b>,
-        TGK::Type: scale::Encode,
-        TGV::Type: PackedLayout,
-    {
-        RawMapping::<TGK::Type, TGV::Type, &Key>::new(&self.offset_key).insert_return_size(key, value)
-    }
+    // /// Insert the given `value` to the contract storage.
+    // ///
+    // /// Returns the size of the pre-existing value at the specified key if any.
+    // #[inline]
+    // pub fn insert_return_size<'a, 'b>(&mut self, key: TGK::Type, value: &TGV::Type) -> Option<u32>
+    // where
+    //     TGK: TypeGuard<'a>,
+    //     TGV: TypeGuard<'b>,
+    //     TGK::Type: scale::Encode,
+    //     TGV::Type: PackedLayout,
+    // {
+    //     RawMapping::<TGK::Type, TGV::Type, &Key>::new(&self.offset_key).insert_return_size(key, value)
+    // }
 
     /// Get the `value` at `key` from the contract storage.
     ///

--- a/lang/src/storage/multi_mapping.rs
+++ b/lang/src/storage/multi_mapping.rs
@@ -116,23 +116,6 @@ where
         for<'a> <TGK as TypeGuard<'a>>::Type: scale::Encode + Copy,
         for<'a> <TGV as TypeGuard<'a>>::Type: PackedLayout,
     {
-        self.insert_return_size(key, value);
-    }
-
-    /// Insert the given `value` to the contract storage at `key`.
-    ///
-    /// Returns the size of the pre-existing value at the specified key if any.
-    pub fn insert_return_size<'b>(
-        &'b mut self,
-        key: <TGK as TypeGuard<'b>>::Type,
-        value: &<TGV as TypeGuard<'b>>::Type,
-    ) -> Option<u32>
-    where
-        for<'a> TGK: TypeGuard<'a>,
-        for<'a> TGV: TypeGuard<'a>,
-        for<'a> <TGK as TypeGuard<'a>>::Type: scale::Encode + Copy,
-        for<'a> <TGV as TypeGuard<'a>>::Type: PackedLayout,
-    {
         let index: u128 = match self.get_index(key, value) {
             None => {
                 let count = self.count(key);
@@ -141,10 +124,37 @@ where
             }
             Some(index) => index,
         };
-        self.value_to_index().insert_return_size(&(key, value), &index);
-        let size = self.index_to_value().insert_return_size(&(key, &index), value);
+        self.value_to_index().insert(&(key, value), &index);
+        let size = self.index_to_value().insert(&(key, &index), value);
         size
     }
+
+    // /// Insert the given `value` to the contract storage at `key`.
+    // ///
+    // /// Returns the size of the pre-existing value at the specified key if any.
+    // pub fn insert_return_size<'b>(
+    //     &'b mut self,
+    //     key: <TGK as TypeGuard<'b>>::Type,
+    //     value: &<TGV as TypeGuard<'b>>::Type,
+    // ) -> Option<u32>
+    // where
+    //     for<'a> TGK: TypeGuard<'a>,
+    //     for<'a> TGV: TypeGuard<'a>,
+    //     for<'a> <TGK as TypeGuard<'a>>::Type: scale::Encode + Copy,
+    //     for<'a> <TGV as TypeGuard<'a>>::Type: PackedLayout,
+    // {
+    //     let index: u128 = match self.get_index(key, value) {
+    //         None => {
+    //             let count = self.count(key);
+    //             self.key_count().insert(key, &(count + 1));
+    //             count
+    //         }
+    //         Some(index) => index,
+    //     };
+    //     self.value_to_index().insert_return_size(&(key, value), &index);
+    //     let size = self.index_to_value().insert_return_size(&(key, &index), value);
+    //     size
+    // }
 
     /// Returns the count of values stored under the `key`.
     #[inline]

--- a/lang/src/storage/raw_mapping.rs
+++ b/lang/src/storage/raw_mapping.rs
@@ -61,20 +61,20 @@ where
         K: scale::Encode,
         V: PackedLayout,
     {
-        self.insert_return_size(key, value);
-    }
-
-    /// Insert the given `value` to the contract storage.
-    ///
-    /// Returns the size of the pre-existing value at the specified key if any.
-    #[inline(always)]
-    pub fn insert_return_size(&self, key: K, value: &V) -> Option<u32>
-    where
-        K: scale::Encode,
-        V: PackedLayout,
-    {
         push_packed_root(value, &self.storage_key(key))
     }
+
+    // /// Insert the given `value` to the contract storage.
+    // ///
+    // /// Returns the size of the pre-existing value at the specified key if any.
+    // #[inline(always)]
+    // pub fn insert_return_size(&self, key: K, value: &V) -> Option<u32>
+    // where
+    //     K: scale::Encode,
+    //     V: PackedLayout,
+    // {
+    //     push_packed_root(value, &self.storage_key(key))
+    // }
 
     /// Get the `value` at `key` from the contract storage.
     ///

--- a/mock/flash-borrower/Cargo.toml
+++ b/mock/flash-borrower/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "flash_borrower"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/mock/psp22-receiver/Cargo.toml
+++ b/mock/psp22-receiver/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "psp22_receiver"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/mock/psp34-receiver/Cargo.toml
+++ b/mock/psp34-receiver/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "psp34_receiver"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/mock/psp35-receiver/Cargo.toml
+++ b/mock/psp35-receiver/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "psp35_receiver"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
 [dependencies]
-ink_primitives = { version = "~3.2.0", default-features = false }
-ink_metadata = { version = "~3.2.0", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "~3.2.0", default-features = false }
-ink_storage = { version = "~3.2.0", default-features = false }
-ink_lang = { version = "~3.2.0", default-features = false }
-ink_prelude = { version = "~3.2.0", default-features = false }
-ink_engine = { version = "~3.2.0", default-features = false, optional = true }
+ink_primitives = { version = "~3.3.0", default-features = false }
+ink_metadata = { version = "~3.3.0", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "~3.3.0", default-features = false }
+ink_storage = { version = "~3.3.0", default-features = false }
+ink_lang = { version = "~3.3.0", default-features = false }
+ink_prelude = { version = "~3.3.0", default-features = false }
+ink_engine = { version = "~3.3.0", default-features = false, optional = true }
 
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }

--- a/tests/e2e/psp35/extensions/burnable.tests.ts
+++ b/tests/e2e/psp35/extensions/burnable.tests.ts
@@ -1,4 +1,5 @@
 import { expect, setupContract } from '../../helpers'
+import exp from "constants";
 
 describe('MY_PSP35_BURNABLE', () => {
   async function setup() {
@@ -18,17 +19,30 @@ describe('MY_PSP35_BURNABLE', () => {
     const amount2 = 20
     
     await expect(contract.tx.mintTo(sender.address, [[token1, amount1], [token2, amount2]])).to.be.fulfilled
-
     await expect(contract.tx.transferFrom(sender.address, alice.address, token1, amount1, [])).to.eventually.be.fulfilled
+
+    await expect(query.balanceOf(sender.address, null)).to.have.output(1)
+    await expect(query.balanceOf(alice.address, null)).to.have.output(1)
 
     await expect(query.balanceOf(alice.address, token1)).to.have.output(amount1)
     await expect(query.balanceOf(sender.address, token2)).to.have.output(amount2)
+    await expect(query.totalSupply(null)).to.have.output(2)
 
     await expect(contract.tx.burn(sender.address, [[token2, amount2]])).to.eventually.be.fulfilled
+
+    await expect(query.balanceOf(sender.address, null)).to.have.output(0)
+    await expect(query.balanceOf(alice.address, null)).to.have.output(1)
+    await expect(query.totalSupply(null)).to.have.output(1)
+    await expect(query.totalSupply(token2)).to.have.output(0)
+    await expect(query.totalSupply(token1)).to.have.output(amount1)
+
     await expect(contract.tx.burn(alice.address, [[token1, amount1]])).to.eventually.be.fulfilled
 
     await expect(query.balanceOf(sender.address, token1)).to.have.output(0)
     await expect(query.balanceOf(alice.address, token2)).to.have.output(0)
+    await expect(query.totalSupply(null)).to.have.output(0)
+    await expect(query.totalSupply(token1)).to.have.output(0)
+    await expect(query.totalSupply(token2)).to.have.output(0)
   })
 
   it('Burn batch works', async () => {
@@ -43,7 +57,7 @@ describe('MY_PSP35_BURNABLE', () => {
     const amount1 = 1
     const amount2 = 10
 
-    await expect(contract.tx.mintTo(sender.address, [[token1, amount1], [token2, 20]])).to.be.fulfilled
+    await expect(contract.tx.mintTo(sender.address, [[token1, amount1], [token2, 20]])).to.eventually.be.fulfilled
 
     await expect(contract.tx.transferFrom(sender.address, alice.address, token2, amount2, [])).to.eventually.be.fulfilled
 

--- a/tests/e2e/psp35/psp35.tests.ts
+++ b/tests/e2e/psp35/psp35.tests.ts
@@ -11,13 +11,47 @@ describe('MY_PSP35', () => {
 
   it('Balance of works', async () => {
     const { query, defaultSigner: sender, tx } = await setup()
-    const token = {
+    const token1 = {
       'u8': 0
     }
+    const token2 = {
+      'u8': 1
+    }
 
-    await expect(query.balanceOf(sender.address, token)).to.have.output(0)
-    await expect(tx.mintTokens(token, 1)).to.eventually.be.fulfilled
-    await expect(query.balanceOf(sender.address, token)).to.have.output(1)
+    const amount1 = 1
+    const amount2 = 20
+
+    await expect(query.balanceOf(sender.address, null)).to.have.output(0)
+    await expect(tx.mintTokens(token1, amount1)).to.eventually.be.fulfilled
+    await expect(tx.mintTokens(token2, amount2)).to.eventually.be.fulfilled
+
+    await expect(query.balanceOf(sender.address, token1)).to.have.output(amount1)
+    await expect(query.balanceOf(sender.address, token2)).to.have.output(amount2)
+    await expect(query.balanceOf(sender.address, null)).to.have.output(2)
+  })
+
+  it('Total supply works', async () => {
+    const { query, defaultSigner: sender, tx } = await setup()
+    const token1 = {
+      'u8': 0
+    }
+    const token2 = {
+      'u8': 1
+    }
+    
+    const amount1 = 1
+    const amount2 = 20
+
+    await expect(query.totalSupply(null)).to.have.output(0)
+    await expect(tx.mintTokens(token1, amount1)).to.eventually.be.fulfilled
+    
+    await expect(query.totalSupply(token1)).to.have.output(amount1)
+    await expect(query.totalSupply(null)).to.have.output(1)
+
+    await expect(tx.mintTokens(token2, amount2)).to.eventually.be.fulfilled
+
+    await expect(query.totalSupply(token2)).to.have.output(amount2)
+    await expect(query.totalSupply(null)).to.have.output(2)
   })
 
   it('Allowance works', async () => {
@@ -127,12 +161,19 @@ describe('MY_PSP35', () => {
     await expect(tx.mintTokens(token1, token1Amount)).to.eventually.be.fulfilled
     await expect(tx.mintTokens(token2, token2Amount)).to.eventually.be.fulfilled
 
+    await expect(query.balanceOf(sender.address, null)).to.have.output(2)
+    await expect(query.balanceOf(sender.address, token1)).to.have.output(token1Amount)
+    await expect(query.balanceOf(sender.address, token2)).to.have.output(token2Amount)
+    await expect(query.totalSupply(null)).to.have.output(2)
+
     await expect(contract.tx.transfer(alice.address, token2, token2Amount, [])).to.eventually.be.fulfilled
 
     await expect(query.balanceOf(sender.address, token1)).to.have.output(token1Amount)
     await expect(query.balanceOf(sender.address, token2)).to.have.output(0)
     await expect(query.balanceOf(alice.address, token1)).to.have.output(0)
     await expect(query.balanceOf(alice.address, token2)).to.have.output(token2Amount)
+    await expect(query.balanceOf(sender.address, null)).to.have.output(1)
+    await expect(query.balanceOf(alice.address, null)).to.have.output(1)
 
     await expect(contract.tx.transfer(alice.address, token1, token1Amount, [])).to.eventually.be.fulfilled
     await expect(fromSigner(contract, alice.address).tx.transfer(sender.address, token2, token1Amount, [])).to.eventually.be.fulfilled
@@ -141,6 +182,8 @@ describe('MY_PSP35', () => {
     await expect(query.balanceOf(sender.address, token2)).to.have.output(token1Amount)
     await expect(query.balanceOf(alice.address, token1)).to.have.output(token1Amount)
     await expect(query.balanceOf(alice.address, token2)).to.have.output(token2Amount - token1Amount)
+    await expect(query.balanceOf(sender.address, null)).to.have.output(1)
+    await expect(query.balanceOf(alice.address, null)).to.have.output(2)
   })
 
   it('Transfer from works', async () => {

--- a/tests/psp35.rs
+++ b/tests/psp35.rs
@@ -198,21 +198,112 @@ mod psp35 {
 
     #[ink::test]
     fn balance_of() {
-        let token_id = Id::U128(1);
-        let mint_amount = 1;
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_amount1 = 1;
+        let token_amount2 = 20;
+
         let accounts = accounts();
         // Create a new contract instance.
         let mut nft = PSP35Struct::new();
         // Token 1 does not exists.
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id1.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.alice, None), 0);
         // mint some token 1
-        assert!(nft.mint(accounts.alice, token_id.clone(), 1).is_ok());
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), mint_amount);
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id2.clone())), token_amount2);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+
+        assert!(nft.transfer(accounts.bob, token_id2.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(
+            nft.balance_of(accounts.alice, Some(token_id2.clone())),
+            token_amount2 - 10
+        );
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id2.clone())), 10);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 1);
+
+        assert!(nft.transfer(accounts.bob, token_id1.clone(), 1, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 1);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
 
         let mut events_iter = ink_env::test::recorded_events();
         let emmited_event = events_iter.next().unwrap();
-        assert_transfer_event(emmited_event, None, Some(accounts.alice), token_id.clone(), mint_amount);
-        assert_eq!(ink_env::test::recorded_events().count(), 1);
+        assert_transfer_event(
+            emmited_event,
+            None,
+            Some(accounts.alice),
+            token_id1.clone(),
+            token_amount1,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            None,
+            Some(accounts.alice),
+            token_id2.clone(),
+            token_amount2,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            Some(accounts.alice),
+            Some(accounts.bob),
+            token_id2.clone(),
+            10,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            Some(accounts.alice),
+            Some(accounts.bob),
+            token_id1.clone(),
+            1,
+        );
+        assert_eq!(ink_env::test::recorded_events().count(), 4);
+    }
+
+    #[ink::test]
+    fn total_supply_works() {
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_id3 = Id::U128(3);
+
+        let token_amount1 = 1;
+        let token_amount2 = 20;
+        let token_amount3 = 1;
+
+        let accounts = accounts();
+        // Create a new contract instance.
+        let mut nft = PSP35Struct::new();
+        assert_eq!(nft.total_supply(None), 0);
+        // mint some token 1
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+
+        assert!(nft.mint(accounts.bob, token_id3.clone(), token_amount3).is_ok());
+
+        assert_eq!(nft.total_supply(None), 3);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+
+        assert!(nft.transfer(accounts.alice, token_id2.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.total_supply(None), 3);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
     }
 
     #[ink::test]
@@ -268,8 +359,8 @@ mod psp35 {
         let result = nft.transfer_from(accounts.alice, accounts.bob, token_id.clone(), transfer_amount, vec![]);
         println!("{:?}", result);
         assert!(result.is_ok());
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.bob, token_id.clone()), transfer_amount);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), transfer_amount);
 
         // EVENTS ASSERTS
         let mut events_iter = ink_env::test::recorded_events();
@@ -338,8 +429,8 @@ mod psp35 {
             .transfer_from(accounts.alice, accounts.bob, token_id.clone(), 1, vec![])
             .is_ok());
 
-        assert_eq!(nft.balance_of(accounts.bob, token_id.clone()), 1);
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), 1);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), 1);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), 1);
         assert_eq!(nft.allowance(accounts.alice, accounts.bob, Some(token_id.clone())), 1);
 
         // EVENTS ASSERTS
@@ -373,8 +464,8 @@ mod psp35 {
         assert!(nft
             .transfer(accounts.bob, token_id.clone(), transfer_amount, vec![])
             .is_ok());
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.bob, token_id.clone()), transfer_amount);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), transfer_amount);
 
         // EVENTS ASSERTS
         let mut events_iter = ink_env::test::recorded_events();

--- a/tests/psp35.rs
+++ b/tests/psp35.rs
@@ -218,22 +218,6 @@ mod psp35 {
 
         assert_eq!(nft.balance_of(accounts.alice, None), 2);
 
-        assert!(nft.transfer(accounts.bob, token_id2.clone(), 10, vec![]).is_ok());
-
-        assert_eq!(
-            nft.balance_of(accounts.alice, Some(token_id2.clone())),
-            token_amount2 - 10
-        );
-        assert_eq!(nft.balance_of(accounts.bob, Some(token_id2.clone())), 10);
-
-        assert_eq!(nft.balance_of(accounts.alice, None), 2);
-        assert_eq!(nft.balance_of(accounts.bob, None), 1);
-
-        assert!(nft.transfer(accounts.bob, token_id1.clone(), 1, vec![]).is_ok());
-
-        assert_eq!(nft.balance_of(accounts.alice, None), 1);
-        assert_eq!(nft.balance_of(accounts.bob, None), 2);
-
         let mut events_iter = ink_env::test::recorded_events();
         let emmited_event = events_iter.next().unwrap();
         assert_transfer_event(
@@ -253,24 +237,7 @@ mod psp35 {
             token_amount2,
         );
 
-        let emmited_event = events_iter.next().unwrap();
-        assert_transfer_event(
-            emmited_event,
-            Some(accounts.alice),
-            Some(accounts.bob),
-            token_id2.clone(),
-            10,
-        );
-
-        let emmited_event = events_iter.next().unwrap();
-        assert_transfer_event(
-            emmited_event,
-            Some(accounts.alice),
-            Some(accounts.bob),
-            token_id1.clone(),
-            1,
-        );
-        assert_eq!(ink_env::test::recorded_events().count(), 4);
+        assert_eq!(ink_env::test::recorded_events().count(), 2);
     }
 
     #[ink::test]
@@ -299,11 +266,6 @@ mod psp35 {
 
         assert_eq!(nft.total_supply(None), 3);
         assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
-
-        assert!(nft.transfer(accounts.alice, token_id2.clone(), 10, vec![]).is_ok());
-
-        assert_eq!(nft.total_supply(None), 3);
-        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
     }
 
     #[ink::test]
@@ -455,17 +417,62 @@ mod psp35 {
 
     #[ink::test]
     fn transfer() {
-        let token_id = Id::U128(1);
-        let transfer_amount = 1;
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_id3 = Id::U128(3);
+        let token_amount1 = 1;
+        let token_amount2 = 20;
+        let token_amount3 = 30;
+
         let accounts = accounts();
         // Create a new contract instance.
         let mut nft = PSP35Struct::new();
-        assert!(nft.mint(accounts.alice, token_id.clone(), transfer_amount).is_ok());
-        assert!(nft
-            .transfer(accounts.bob, token_id.clone(), transfer_amount, vec![])
-            .is_ok());
-        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), 0);
-        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), transfer_amount);
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+        assert!(nft.mint(accounts.alice, token_id3.clone(), token_amount3).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 3);
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+        assert_eq!(nft.total_supply(None), 3);
+
+        assert!(nft.transfer(accounts.bob, token_id2.clone(), 10, vec![]).is_ok());
+        assert!(nft.transfer(accounts.bob, token_id3.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id2.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id3.clone())), 20);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id2.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id3.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.alice, None), 3);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
+
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+        assert_eq!(nft.total_supply(None), 3);
+
+        assert!(nft.transfer(accounts.charlie, token_id3.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id3.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.charlie, Some(token_id3.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.alice, None), 3);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
+        assert_eq!(nft.balance_of(accounts.charlie, None), 1);
+
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+
+        assert!(nft.transfer(accounts.charlie, token_id3.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id3.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.charlie, Some(token_id3.clone())), 20);
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
+        assert_eq!(nft.balance_of(accounts.charlie, None), 1);
+
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+        assert_eq!(nft.total_supply(None), 3);
 
         // EVENTS ASSERTS
         let mut events_iter = ink_env::test::recorded_events();
@@ -474,8 +481,26 @@ mod psp35 {
             emmited_event,
             None,
             Some(accounts.alice),
-            token_id.clone(),
-            transfer_amount,
+            token_id1.clone(),
+            token_amount1,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            None,
+            Some(accounts.alice),
+            token_id2.clone(),
+            token_amount2,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            None,
+            Some(accounts.alice),
+            token_id3.clone(),
+            token_amount3,
         );
 
         let emmited_event = events_iter.next().unwrap();
@@ -483,11 +508,38 @@ mod psp35 {
             emmited_event,
             Some(accounts.alice),
             Some(accounts.bob),
-            token_id.clone(),
-            transfer_amount,
+            token_id2.clone(),
+            10,
         );
 
-        assert_eq!(ink_env::test::recorded_events().count(), 2);
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            Some(accounts.alice),
+            Some(accounts.bob),
+            token_id3.clone(),
+            10,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            Some(accounts.alice),
+            Some(accounts.charlie),
+            token_id3.clone(),
+            10,
+        );
+
+        let emmited_event = events_iter.next().unwrap();
+        assert_transfer_event(
+            emmited_event,
+            Some(accounts.alice),
+            Some(accounts.charlie),
+            token_id3.clone(),
+            10,
+        );
+
+        assert_eq!(ink_env::test::recorded_events().count(), 7);
     }
 
     #[ink::test]

--- a/tests/psp35_batch.rs
+++ b/tests/psp35_batch.rs
@@ -138,13 +138,18 @@ mod psp35_batch {
         let mut nft = PSP35Struct::new();
         assert!(nft.mint(accounts.alice, ids_amounts.clone()).is_ok());
 
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+
         assert!(nft.batch_transfer(accounts.bob, ids_amounts.clone(), vec![]).is_ok());
 
-        assert_eq!(nft.balance_of(accounts.alice, token_id1.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.alice, token_id2.clone()), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id1.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id2.clone())), 0);
 
-        assert_eq!(nft.balance_of(accounts.bob, token_id1), id_1_amount);
-        assert_eq!(nft.balance_of(accounts.bob, token_id2), id_2_amount);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id1)), id_1_amount);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id2)), id_2_amount);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 0);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
 
         // EVENTS ASSERTS
         let mut events_iter = ink_env::test::recorded_events();
@@ -173,21 +178,27 @@ mod psp35_batch {
         let mut nft = PSP35Struct::new();
         assert!(nft.mint(accounts.alice, ids_amounts.clone()).is_ok());
 
-        assert_eq!(nft.balance_of(accounts.bob, token_id_1.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.bob, token_id_2.clone()), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_1.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_2.clone())), 0);
 
-        assert_eq!(nft.balance_of(accounts.alice, token_id_1.clone()), amounts[0]);
-        assert_eq!(nft.balance_of(accounts.alice, token_id_2.clone()), amounts[1]);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_1.clone())), amounts[0]);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_2.clone())), amounts[1]);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 0);
 
         assert!(nft
             .batch_transfer_from(accounts.alice, accounts.bob, ids_amounts.clone(), vec![])
             .is_ok());
 
-        assert_eq!(nft.balance_of(accounts.bob, token_id_1.clone()), amounts[0]);
-        assert_eq!(nft.balance_of(accounts.bob, token_id_2.clone()), amounts[1]);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_1.clone())), amounts[0]);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_2.clone())), amounts[1]);
 
-        assert_eq!(nft.balance_of(accounts.alice, token_id_1.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.alice, token_id_2.clone()), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_1.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_2.clone())), 0);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 0);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
     }
 
     #[ink::test]
@@ -255,10 +266,13 @@ mod psp35_batch {
             .batch_transfer_from(accounts.alice, accounts.bob, ids_amounts.clone(), vec![])
             .is_ok());
 
-        assert_eq!(nft.balance_of(accounts.bob, token_id_1.clone()), amounts[0]);
-        assert_eq!(nft.balance_of(accounts.bob, token_id_2.clone()), amounts[1]);
-        assert_eq!(nft.balance_of(accounts.alice, token_id_1), 0);
-        assert_eq!(nft.balance_of(accounts.alice, token_id_2), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_1.clone())), amounts[0]);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_2.clone())), amounts[1]);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_1)), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_2)), 0);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 0);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
 
         // EVENTS ASSERTS
         let mut events_iter = ink_env::test::recorded_events();

--- a/tests/psp35_burnable.rs
+++ b/tests/psp35_burnable.rs
@@ -89,30 +89,41 @@ mod psp35_burnable {
 
     #[ink::test]
     fn burn_works() {
-        let token_id = Id::U128(123);
-        let token_amount = 20;
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_amount1 = 1;
+        let token_amount2 = 10;
         let accounts = accounts();
 
         let mut nft = PSP35Struct::new();
-        assert!(nft.mint(accounts.alice, token_id.clone(), token_amount).is_ok());
-        assert!(nft.mint(accounts.bob, token_id.clone(), token_amount).is_ok());
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
 
-        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), token_amount);
-        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), token_amount);
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.total_supply(None), 2);
+
+        assert!(nft.mint(accounts.bob, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), 20);
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 1);
+
+        assert!(nft.burn(accounts.bob, vec![(token_id2.clone(), token_amount2)]).is_ok());
+
+        assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), 10);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 0);
+
+        assert!(nft
+            .burn(accounts.alice, vec![(token_id2.clone(), token_amount2)])
+            .is_ok());
 
         assert_eq!(nft.total_supply(None), 1);
-        assert_eq!(nft.total_supply(Some(token_id.clone())), 2 * token_amount);
-
-        assert!(nft.burn(accounts.alice, vec![(token_id.clone(), token_amount)]).is_ok());
-        assert!(nft.burn(accounts.bob, vec![(token_id.clone(), token_amount)]).is_ok());
-
-        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), 0);
-        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), 0);
-
-        assert_eq!(nft.balance_of(accounts.alice, None), 0);
-        assert_eq!(nft.balance_of(accounts.bob, None), 0);
-        assert_eq!(nft.total_supply(None), 0);
-        assert_eq!(nft.total_supply(Some(token_id.clone())), 0);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.alice, None), 1);
     }
 
     #[ink::test]

--- a/tests/psp35_burnable.rs
+++ b/tests/psp35_burnable.rs
@@ -105,11 +105,17 @@ mod psp35_burnable {
         assert!(nft.mint(accounts.bob, token_id2.clone(), token_amount2).is_ok());
 
         assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), 1);
         assert_eq!(nft.total_supply(Some(token_id2.clone())), 20);
         assert_eq!(nft.balance_of(accounts.alice, None), 2);
         assert_eq!(nft.balance_of(accounts.bob, None), 1);
 
-        assert!(nft.burn(accounts.bob, vec![(token_id2.clone(), token_amount2)]).is_ok());
+        assert!(nft
+            .burn(
+                accounts.bob,
+                vec![(token_id2.clone(), token_amount2), (token_id1.clone(), 0)]
+            )
+            .is_ok());
 
         assert_eq!(nft.total_supply(None), 2);
         assert_eq!(nft.total_supply(Some(token_id2.clone())), 10);

--- a/tests/psp35_burnable.rs
+++ b/tests/psp35_burnable.rs
@@ -97,14 +97,22 @@ mod psp35_burnable {
         assert!(nft.mint(accounts.alice, token_id.clone(), token_amount).is_ok());
         assert!(nft.mint(accounts.bob, token_id.clone(), token_amount).is_ok());
 
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), token_amount);
-        assert_eq!(nft.balance_of(accounts.bob, token_id.clone()), token_amount);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), token_amount);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), token_amount);
+
+        assert_eq!(nft.total_supply(None), 1);
+        assert_eq!(nft.total_supply(Some(token_id.clone())), 2 * token_amount);
 
         assert!(nft.burn(accounts.alice, vec![(token_id.clone(), token_amount)]).is_ok());
         assert!(nft.burn(accounts.bob, vec![(token_id.clone(), token_amount)]).is_ok());
 
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.bob, token_id.clone()), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id.clone())), 0);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 0);
+        assert_eq!(nft.balance_of(accounts.bob, None), 0);
+        assert_eq!(nft.total_supply(None), 0);
+        assert_eq!(nft.total_supply(Some(token_id.clone())), 0);
     }
 
     #[ink::test]

--- a/tests/psp35_enumerable.rs
+++ b/tests/psp35_enumerable.rs
@@ -76,6 +76,11 @@ mod psp35_enumerable {
         pub fn new() -> Self {
             ink_lang::codegen::initialize_contract(|_instance: &mut Self| {})
         }
+
+        #[ink(message)]
+        pub fn mint(&mut self, acc: AccountId, id: Id, amount: Balance) -> Result<(), PSP35Error> {
+            self._mint_to(acc, vec![(id, amount)])
+        }
     }
 
     #[ink::test]
@@ -313,5 +318,161 @@ mod psp35_enumerable {
         assert_eq!(nft.owners_token_by_index(accounts.alice, 0u128), None);
         // token by index 1 does not exists
         assert_eq!(nft.token_by_index(0u128), None);
+    }
+
+    #[ink::test]
+    fn total_supply_works() {
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_id3 = Id::U128(3);
+
+        let token_amount1 = 1;
+        let token_amount2 = 20;
+        let token_amount3 = 1;
+
+        let accounts = accounts();
+        // Create a new contract instance.
+        let mut nft = PSP35Struct::new();
+        assert_eq!(nft.total_supply(None), 0);
+        // mint some token 1
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+
+        assert!(nft.mint(accounts.bob, token_id3.clone(), token_amount3).is_ok());
+
+        assert_eq!(nft.total_supply(None), 3);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+    }
+
+    #[ink::test]
+    fn balance_of() {
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_amount1 = 1;
+        let token_amount2 = 20;
+
+        let accounts = accounts();
+        // Create a new contract instance.
+        let mut nft = PSP35Struct::new();
+        // Token 1 does not exists.
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id1.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.alice, None), 0);
+        // mint some token 1
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id2.clone())), token_amount2);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+    }
+
+    #[ink::test]
+    fn transfer() {
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_id3 = Id::U128(3);
+        let token_amount1 = 1;
+        let token_amount2 = 20;
+        let token_amount3 = 30;
+
+        let accounts = accounts();
+        // Create a new contract instance.
+        let mut nft = PSP35Struct::new();
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+        assert!(nft.mint(accounts.alice, token_id3.clone(), token_amount3).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 3);
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+        assert_eq!(nft.total_supply(None), 3);
+
+        assert!(nft.transfer(accounts.bob, token_id2.clone(), 10, vec![]).is_ok());
+        assert!(nft.transfer(accounts.bob, token_id3.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id2.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id3.clone())), 20);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id2.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id3.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.alice, None), 3);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
+
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+        assert_eq!(nft.total_supply(None), 3);
+
+        assert!(nft.transfer(accounts.charlie, token_id3.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id3.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.charlie, Some(token_id3.clone())), 10);
+        assert_eq!(nft.balance_of(accounts.alice, None), 3);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
+        assert_eq!(nft.balance_of(accounts.charlie, None), 1);
+
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+
+        assert!(nft.transfer(accounts.charlie, token_id3.clone(), 10, vec![]).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id3.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.charlie, Some(token_id3.clone())), 20);
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 2);
+        assert_eq!(nft.balance_of(accounts.charlie, None), 1);
+
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), token_amount1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), token_amount2);
+        assert_eq!(nft.total_supply(Some(token_id3.clone())), token_amount3);
+        assert_eq!(nft.total_supply(None), 3);
+    }
+
+    #[ink::test]
+    fn burn_works() {
+        let token_id1 = Id::U128(1);
+        let token_id2 = Id::U128(2);
+        let token_amount1 = 1;
+        let token_amount2 = 10;
+        let accounts = accounts();
+
+        let mut nft = PSP35Struct::new();
+        assert!(nft.mint(accounts.alice, token_id1.clone(), token_amount1).is_ok());
+        assert!(nft.mint(accounts.alice, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.total_supply(None), 2);
+
+        assert!(nft.mint(accounts.bob, token_id2.clone(), token_amount2).is_ok());
+
+        assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id1.clone())), 1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), 20);
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 1);
+
+        assert!(nft
+            .burn(
+                accounts.bob,
+                vec![(token_id2.clone(), token_amount2), (token_id1.clone(), 0)]
+            )
+            .is_ok());
+
+        assert_eq!(nft.total_supply(None), 2);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), 10);
+
+        assert_eq!(nft.balance_of(accounts.alice, None), 2);
+        assert_eq!(nft.balance_of(accounts.bob, None), 0);
+
+        assert!(nft
+            .burn(accounts.alice, vec![(token_id2.clone(), token_amount2)])
+            .is_ok());
+
+        assert_eq!(nft.total_supply(None), 1);
+        assert_eq!(nft.total_supply(Some(token_id2.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.alice, None), 1);
     }
 }

--- a/tests/psp35_mintable.rs
+++ b/tests/psp35_mintable.rs
@@ -91,8 +91,10 @@ mod psp35_mintable {
         let accounts = accounts();
 
         let mut nft = PSP35Struct::new();
-        assert_eq!(nft.balance_of(accounts.alice, token_id_1.clone()), 0);
-        assert_eq!(nft.balance_of(accounts.bob, token_id_2.clone()), 0);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_1.clone())), 0);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_2.clone())), 0);
+
+        assert_eq!(nft.total_supply(None), 0);
 
         assert!(nft
             .mint(accounts.alice, vec![(token_id_1.clone(), token_1_amount)])
@@ -101,8 +103,9 @@ mod psp35_mintable {
             .mint(accounts.bob, vec![(token_id_2.clone(), token_2_amount)])
             .is_ok());
 
-        assert_eq!(nft.balance_of(accounts.alice, token_id_1.clone()), token_1_amount);
-        assert_eq!(nft.balance_of(accounts.bob, token_id_2.clone()), token_2_amount);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id_1.clone())), token_1_amount);
+        assert_eq!(nft.balance_of(accounts.bob, Some(token_id_2.clone())), token_2_amount);
+        assert_eq!(nft.total_supply(None), 2);
     }
 
     #[ink::test]
@@ -113,7 +116,7 @@ mod psp35_mintable {
         let mut nft = PSP35Struct::new();
         // Can mint
         assert!(nft.mint(accounts.alice, vec![(token_id.clone(), amount)]).is_ok());
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), amount);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), amount);
         // Turn on error on _before_token_transfer
         nft.change_state_err_on_before();
         // Alice gets an error on _before_token_transfer
@@ -131,7 +134,7 @@ mod psp35_mintable {
         let mut nft = PSP35Struct::new();
         // Can mint
         assert!(nft.mint(accounts.alice, vec![(token_id.clone(), amount)]).is_ok());
-        assert_eq!(nft.balance_of(accounts.alice, token_id.clone()), amount);
+        assert_eq!(nft.balance_of(accounts.alice, Some(token_id.clone())), amount);
         // Turn on error on _after_token_transfer
         nft.change_state_err_on_after();
         // Alice gets an error on _after_token_transfer


### PR DESCRIPTION
OpenBrush release `2.1.0`:
- Updated the ink! to the `3.3.0` version.
- Added `MultiMapping`, `Mapping`, and `RawMapping` that can be used to protect the code from monomorphization. The user can specify the key and value that he expects to use during interacting with those structures and that type should be used across all places. It helps to avoid duplicating code for a few different types like `AccountId` and `&AccountId`.
- Optimized the implementation of `PSP34Enumerable` and also changed the way how to get enumerable functionality.
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/18346821/175323158-075f4085-0318-44d3-b519-ffbaf4db362d.png">

- Optimized all contract with `openbrush::storage::Mapping`.
- Renamed `PSP1155` into `PSP35` and refactored it according to the proposal.
- Implemented `AccessControlEnumerable` and `PSP35Enumerable`.
- Added documentation with GIFs regarding deployment of contracts on different parachains/blockchains.

It is a preparation release before a new [storage system](https://github.com/Supercolony-net/openbrush-contracts/pull/137).