### PR TITLE
Openbrush release v2.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,14 +112,19 @@ jobs:
       env:
         CARGO_TARGET_DIR: /usr/local/cache/target
     steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - uses: actions/checkout@v3
+
       - name: Cache rust artifacts for source branch
         id: cache-rust-artifacts-source
         uses: actions/cache@v3
         with:
           path: /usr/local/cache/target
-          key: cache-rust-artifacts-pr-${{ hashFiles('Cargo.toml') }}-${{ github.ref }}
+          key: cache-rust-artifacts-${{ hashFiles('Cargo.toml') }}-${{ github.ref }}
           restore-keys: |
-            cache-rust-artifacts-pr-${{ hashFiles('Cargo.toml') }}
+            cache-rust-artifacts-${{ hashFiles('Cargo.toml') }}
 
       - name: Find contract data for source branch
         id: find-data-source

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 
 [package]
 name = "openbrush"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2018"
 
@@ -38,8 +38,8 @@ ink_engine = { version = "~3.4.0", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-openbrush_contracts = { version = "~2.2.0", path = "contracts", default-features = false }
-openbrush_lang = { version = "~2.2.0", path = "lang", default-features = false }
+openbrush_contracts = { version = "~2.3.0", path = "contracts", default-features = false }
+openbrush_lang = { version = "~2.3.0", path = "lang", default-features = false }
 
 [lib]
 name = "openbrush"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_contracts"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -26,7 +26,7 @@ ink_engine = { version = "~3.4.0", default-features = false, optional = true }
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
-openbrush = { version = "~2.2.0", package = "openbrush_lang", path = "../lang", default-features = false }
+openbrush = { version = "~2.3.0", package = "openbrush_lang", path = "../lang", default-features = false }
 
 pallet-assets-chain-extension = { git = "https://github.com/Supercolony-net/pallet-assets-chain-extension", default-features = false, features = ["ink"]  }
 

--- a/docs/docs/smart-contracts/example/contract.md
+++ b/docs/docs/smart-contracts/example/contract.md
@@ -16,7 +16,7 @@ implementation of `Lending` and `LendingPermissioned` traits defined in the `len
 ```toml
 [package]
 name = "lending_contract"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 shares_contract = { path = "../shares", default-features = false, features = ["ink-as-dependency"]  }
 loan_contract = { path = "../loan", default-features = false, features = ["ink-as-dependency"]  }
 lending_project = { path = "../..", default-features = false }
-openbrush = { version = "~2.2.0", default-features = false, features = ["pausable", "access_control"] }
+openbrush = { version = "~2.3.0", default-features = false, features = ["pausable", "access_control"] }
 
 [lib]
 name = "lending_contract"

--- a/docs/docs/smart-contracts/overview.md
+++ b/docs/docs/smart-contracts/overview.md
@@ -30,7 +30,7 @@ scale = { package = "parity-scale-codec", version = "3", default-features = fals
 scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
 
 # Brush dependency
-openbrush = { version = "~2.2.0", default-features = false }
+openbrush = { version = "~2.3.0", default-features = false }
 
 [features]
 default = ["std"]
@@ -89,17 +89,17 @@ The name of the feature is the same as the name of the module. For example:
 
 To enable `psp22`:
 ```toml
-openbrush = { version = "~2.2.0", default-features = false, features = ["psp22"] }
+openbrush = { version = "~2.3.0", default-features = false, features = ["psp22"] }
 ```
 
 To enable `ownable`:
 ```toml
-openbrush = { version = "~2.2.0", default-features = false, features = ["ownable"] }
+openbrush = { version = "~2.3.0", default-features = false, features = ["ownable"] }
 ```
 
 To enable both:
 ```toml
-openbrush = { version = "~2.2.0", default-features = false, features = ["psp22", "ownable"] }
+openbrush = { version = "~2.3.0", default-features = false, features = ["psp22", "ownable"] }
 ```
 
 After enabling the feature and importing the corresponding module, you need to embed the module 

--- a/example_project_structure/Cargo.toml
+++ b/example_project_structure/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_project"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net, dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/lending/Cargo.toml
+++ b/example_project_structure/contracts/lending/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lending_contract"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/loan/Cargo.toml
+++ b/example_project_structure/contracts/loan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "loan_contract"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/shares/Cargo.toml
+++ b/example_project_structure/contracts/shares/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shares_contract"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/example_project_structure/contracts/stable_coin/Cargo.toml
+++ b/example_project_structure/contracts/stable_coin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stable_coin_contract"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/access_control/Cargo.toml
+++ b/examples/access_control/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_access_control"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/access_control_extensions/enumerable/Cargo.toml
+++ b/examples/access_control_extensions/enumerable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_access_control_enumerable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <nameless.endless@supercolony.net>"]
 edition = "2021"
 

--- a/examples/alternatives/diamond/ink/Cargo.toml
+++ b/examples/alternatives/diamond/ink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ink_diamond"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/alternatives/diamond/rust/Cargo.toml
+++ b/examples/alternatives/diamond/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_diamond"
-version = "2.0.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/Cargo.toml
+++ b/examples/diamond/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_diamond"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/diamond_caller/Cargo.toml
+++ b/examples/diamond/diamond_caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diamond_caller"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_facet_v1/Cargo.toml
+++ b/examples/diamond/psp22_facet_v1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_facet_v1"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_facet_v2/Cargo.toml
+++ b/examples/diamond/psp22_facet_v2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_facet_v2"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/diamond/psp22_metadata_facet/Cargo.toml
+++ b/examples/diamond/psp22_metadata_facet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata_facet"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_ownable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/pausable/Cargo.toml
+++ b/examples/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_pausable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/payment_splitter/Cargo.toml
+++ b/examples/payment_splitter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_payment_splitter"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/Cargo.toml
+++ b/examples/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_proxy"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_metadata_upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata_upgradeable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/proxy/psp22_upgradeable/Cargo.toml
+++ b/examples/proxy/psp22_upgradeable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_upgradeable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <horacio.lex@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22/Cargo.toml
+++ b/examples/psp22/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/burnable/Cargo.toml
+++ b/examples/psp22_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_burnable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/capped/Cargo.toml
+++ b/examples/psp22_extensions/capped/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_capped"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/flashmint/Cargo.toml
+++ b/examples/psp22_extensions/flashmint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_flashmint"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/metadata/Cargo.toml
+++ b/examples/psp22_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_metadata"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/mintable/Cargo.toml
+++ b/examples/psp22_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_mintable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <m.konstantinovna@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/pausable/Cargo.toml
+++ b/examples/psp22_extensions/pausable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pausable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_extensions/wrapper/Cargo.toml
+++ b/examples/psp22_extensions/wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_wrapper"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_pallet/Cargo.toml
+++ b/examples/psp22_pallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pallet"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_pallet_extensions/burnable/Cargo.toml
+++ b/examples/psp22_pallet_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pallet_burnable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <nameless.endless@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_pallet_extensions/metadata/Cargo.toml
+++ b/examples/psp22_pallet_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pallet_metadata"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <nameless.endless@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_pallet_extensions/mintable/Cargo.toml
+++ b/examples/psp22_pallet_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_pallet_mintable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <nameless.endless@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp22_utils/token_timelock/Cargo.toml
+++ b/examples/psp22_utils/token_timelock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp22_token_timelock"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34/Cargo.toml
+++ b/examples/psp34/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/burnable/Cargo.toml
+++ b/examples/psp34_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_burnable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/enumerable/Cargo.toml
+++ b/examples/psp34_extensions/enumerable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_enumerable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/metadata/Cargo.toml
+++ b/examples/psp34_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_metadata"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp34_extensions/mintable/Cargo.toml
+++ b/examples/psp34_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp34_mintable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp37/Cargo.toml
+++ b/examples/psp37/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp37"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp37_extensions/batch/Cargo.toml
+++ b/examples/psp37_extensions/batch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp37_batch"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <artem.lech@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp37_extensions/burnable/Cargo.toml
+++ b/examples/psp37_extensions/burnable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp37_burnable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp37_extensions/enumerable/Cargo.toml
+++ b/examples/psp37_extensions/enumerable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp37_enumerable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <artem.lech@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp37_extensions/metadata/Cargo.toml
+++ b/examples/psp37_extensions/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp37_metadata"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/psp37_extensions/mintable/Cargo.toml
+++ b/examples/psp37_extensions/mintable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_psp37_mintable"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/Cargo.toml
+++ b/examples/reentrancy_guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flipper"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flip_on_me/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flip_on_me"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/reentrancy_guard/contracts/flipper/Cargo.toml
+++ b/examples/reentrancy_guard/contracts/flipper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_flipper_guard"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/examples/timelock_controller/Cargo.toml
+++ b/examples/timelock_controller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "my_timelock_controller"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/lang/Cargo.toml
+++ b/lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -14,7 +14,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-openbrush_lang_macro = { version = "~2.2.0", path = "macro", default-features = false }
+openbrush_lang_macro = { version = "~2.3.0", path = "macro", default-features = false }
 
 ink_env = { version = "~3.4.0", default-features = false }
 ink_lang = { version = "~3.4.0", default-features = false }

--- a/lang/codegen/Cargo.toml
+++ b/lang/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang_codegen"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/lang/macro/Cargo.toml
+++ b/lang/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openbrush_lang_macro"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 
@@ -14,7 +14,7 @@ categories = ["no-std", "embedded"]
 include = ["Cargo.toml", "src/**/*.rs"]
 
 [dependencies]
-openbrush_lang_codegen = { version = "~2.2.0", path = "../codegen", default-features = false }
+openbrush_lang_codegen = { version = "~2.3.0", path = "../codegen", default-features = false }
 syn = "1"
 proc-macro2 = "1"
 synstructure = "0.12"

--- a/mock/flash-borrower/Cargo.toml
+++ b/mock/flash-borrower/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flash_borrower"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <dominik.krizo@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp22-receiver/Cargo.toml
+++ b/mock/psp22-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22_receiver"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp34-receiver/Cargo.toml
+++ b/mock/psp34-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp34_receiver"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 

--- a/mock/psp37-receiver/Cargo.toml
+++ b/mock/psp37-receiver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp37_receiver"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Supercolony <green.baneling@supercolony.net>"]
 edition = "2021"
 


### PR DESCRIPTION
- Updated ink! version to `3.4.0`
- Renamed `PSP35` to `PSP37`
- Integrated Typechain for tests instead of Redspot